### PR TITLE
Fixup benchmarks and dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,84 +4,92 @@ version = "0.3.8"
 authors = ["Heinz N. Gies <heinz@licenser.net>", "Sunny Gleason"]
 edition = "2018"
 exclude = [ "data/*", "fuzz/*"]
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 description = "High performance JSON parser based on a port of simdjson"
 repository = "https://github.com/simd-lite/simd-json"
-readme = "./README.md"
+readme = "README.md"
 documentation = "https://docs.rs/simd-json"
 
-[workspace]
-
-
 [dependencies]
+beef = { version = "0.4", optional = true }
 halfbrown = "0.1"
-
-value-trait = "0.1.7"
+simd-lite = { version = "0.1", optional = true }
+value-trait = "0.1"
 
 # serde compatibilty
 serde = { version = "1", features = ["derive"], optional = true}
-serde_json = { version = "1", optional = true}
+serde_json = { version = "1", optional = true }
 
+# perf testing
+alloc_counter = {version = "0.0.4", optional = true }
+colored = { version = "1.9", optional = true }
+getopts = { version = "0.2", optional = true }
 jemallocator = { version = "0.3", optional = true }
 perfcnt = { version = "0.5", optional = true }
-getopts = { version = "0.2", optional = true }
-colored = { version = "1.9", optional = true }
-simd-lite = { version = "0.1.0", optional = true }
-beef = { version = "0.4.1", optional = true }
 
-# for float comparison
-float-cmp = "0.6"
-
-# because dev dependenceis can't be optional ...
-alloc_counter = {version = "0.0.4", optional = true}
+# benchmarking
+core_affinity = { version = "0.5", optional = true }
+criterion = { version = "0.3", optional = true }
 
 [dev-dependencies]
+float-cmp = "0.6"
 getopts = "0.2"
 proptest = "0.9"
-serde_derive = "1"
-serde_bytes = "0.11"
-criterion = "0.3"
-#criterion = { path = "../criterion.rs" }
-core_affinity = "0.5"
-
 
 [[bench]]
 name = "parse"
 harness = false
 
-
 [features]
 default = ["swar-number-parsing", "serde_impl"]
+
 # Support for 128 bit integers
 128bit = ["value-trait/128bit"]
+
 # used for enabeling known keys in favour of a slower
 # hasher that is not protected against hash collision
 # attacks
 known-key = [ "halfbrown/fxhash" ]
+
 # use 8 number at once parsing strategy
 swar-number-parsing = []
+
 # serde compatibility
 serde_impl = [ "serde", "serde_json", "halfbrown/serde" ]
+
 # Support for ARM NEON SIMD
 neon = ["simd-lite", "value-trait/neon"]
+
 # Allow fallback to non simd CPUs
 allow-non-simd = []
+
 # for testing allocations
 alloc = ["alloc_counter"]
+
 # don't inline code - used for debugging
 no-inline = []
+
 # uses safe slice access ([]) instead of get_unsafe
 # **for debugging**
 safe = []
+
+# dependencies only needed for cargo bench
+bench = ["criterion", "core_affinity"]
+
 # also bench serde in the benchmarks
-bench-serde = []
+bench-serde = ["serde_json"]
+
 # use branch hints - requires nightly :(
 hints = [] # requires nightly
+
 # for perf testing, used by the example
-perf = ["perfcnt", "getopts", "colored"]
+perf = ["perfcnt", "getopts", "colored", "serde_json"]
 
 [[example]]
 name = "perf"
 
-# [patch.crates-io]
-# value-trait = { path = '../value-trait' }
+[profile.bench]
+lto = "thin"
+
+[profile.release]
+lto = "thin"

--- a/examples/perf.rs
+++ b/examples/perf.rs
@@ -212,6 +212,7 @@ mod int {
 }
 
 fn main() {
+    // e.g.: cargo run --release --example perf --features perf -- --baseline
     let mut opts = getopts::Options::new();
     opts.optflag("b", "baseline", "create baseline");
     let args: Vec<String> = env::args().collect();


### PR DESCRIPTION
The benches now include simd_json::to_tape, drop the C++ FFI crate
because it's not on cargo and anyway out of date, and use thinLTO
to be more representative.

This reduces the dependencies needed for cargo test from 133
to 85 by putting benchmarking-only dependencies behind a feature.
It's ~30% faster to compile.