### PR TITLE
Remove another dbg macro call

### DIFF
--- a/src/serde/se.rs
+++ b/src/serde/se.rs
@@ -521,7 +521,6 @@ where
         _name: &'static str,
         len: usize,
     ) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        dbg!();
         self.serialize_seq(Some(len))
     }
 


### PR DESCRIPTION
Hi there, sorry for this second PR. :flushed: 
I oversaw another `dbg!()` in the other PR which was also there. The last PR was really just copy-from-stacktrace-and-remove-in-fork, but this is according to the search the last call to the debug macro left in the codebase. Maybe I should've looked a bit closer before submitting that one.