### PR TITLE
Add KnownKey::map* methods for lookups on Value::Objects inner maps.

### DIFF
--- a/src/known_key.rs
+++ b/src/known_key.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::hash::{BuildHasher, Hash, Hasher};
 
 /// Well known key that can be looked up in a `Value` faster.
-/// It achives this by memorizing the hash.
+/// It achieves this by memorizing the hash.
 #[derive(Debug, Clone, PartialEq)]
 pub struct KnownKey<'key> {
     key: Cow<'key, str>,
@@ -81,7 +81,35 @@ impl<'key> KnownKey<'key> {
     {
         target
             .as_object()
-            .and_then(|m| m.raw_entry().from_key_hashed_nocheck(self.hash, &self.key))
+            .and_then(|m| self.map_lookup(m))
+    }
+
+	/// Looks up this key in a `HashMap<<Cow<'value, str>, Value<'value>>` the inner representation of an object `Value`, returns None if the
+    /// key wasn't present.
+    ///
+    /// ```rust
+    /// use tremor_value::prelude::*;
+    /// let object = literal!({
+    ///   "answer": 42,
+    ///   "key": 7
+    /// });
+    /// let known_key = KnownKey::from("answer");
+    /// if let Some(inner) = object.as_object() {
+    ///   assert_eq!(known_key.map_lookup(inner).unwrap(), &42);
+    /// }
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn map_lookup<'target, 'value>(
+        &self,
+        map: &'target halfbrown::HashMap<Cow<'value, str>, Value<'value>>,
+    ) -> Option<&'target Value<'value>>
+    where
+        'key: 'value,
+        'value: 'target,
+    {
+        map.raw_entry()
+            .from_key_hashed_nocheck(self.hash, &self.key)
             .map(|kv| kv.1)
     }
 
@@ -113,15 +141,46 @@ impl<'key> KnownKey<'key> {
         'key: 'value,
         'value: 'target,
     {
-        target.as_object_mut().and_then(|m| {
-            match m
-                .raw_entry_mut()
-                .from_key_hashed_nocheck(self.hash, &self.key)
-            {
-                RawEntryMut::Occupied(e) => Some(e.into_mut()),
-                RawEntryMut::Vacant(_e) => None,
-            }
-        })
+        target.as_object_mut().and_then(|m| self.map_lookup_mut(m))
+    }
+
+    /// Looks up this key in a `HashMap<Cow<'value, str>, Value<'value>>`, the inner representation of an object value.
+    /// returns None if the key wasn't present.
+    ///
+    /// ```rust
+    /// use tremor_value::prelude::*;
+    /// let mut object = literal!({
+    ///   "answer": 23,
+    ///   "key": 7
+    /// });
+    ///
+    /// assert_eq!(object["answer"], 23);
+    ///
+    /// let known_key = KnownKey::from("answer");
+    /// if let Some(inner) = object.as_object_mut() {
+    ///   if let Some(answer) = known_key.map_lookup_mut(inner) {
+    ///     *answer = Value::from(42);
+    ///   }
+    /// }
+    /// assert_eq!(object["answer"], 42);
+    ///
+    /// ```
+    #[inline]
+    pub fn map_lookup_mut<'target, 'value>(
+        &self,
+        map: &'target mut halfbrown::HashMap<Cow<'value, str>, Value<'value>>,
+    ) -> Option<&'target mut Value<'value>>
+    where
+        'key: 'value,
+        'value: 'target,
+    {
+        match map
+            .raw_entry_mut()
+            .from_key_hashed_nocheck(self.hash, &self.key)
+        {
+            RawEntryMut::Occupied(e) => Some(e.into_mut()),
+            RawEntryMut::Vacant(_e) => None,
+        }
     }
 
     /// Looks up this key in a `Value`, inserts `with` when the key
@@ -165,18 +224,57 @@ impl<'key> KnownKey<'key> {
         'value: 'target,
         F: FnOnce() -> Value<'value>,
     {
-        if !target.is_object() {
-            return Err(Error::NotAnObject(target.value_type()));
+        match target {
+            Value::Object(inner) => Ok(self.map_lookup_or_insert_mut(m, with)),
+            other => Err(Error::NotAnObject(target.value_type()))
         }
-        target
-            .as_object_mut()
-            .map(|m| {
-                m.raw_entry_mut()
-                    .from_key_hashed_nocheck(self.hash, &self.key)
-                    .or_insert_with(|| (self.key.clone(), with()))
-                    .1
-            })
-            .ok_or(Error::NotAnObject(ValueType::Null))
+    }
+
+    /// Looks up this key in a `HashMap<Cow<'value, str>, Value<'value>>`, the inner representation of an object `Value`.
+    /// Inserts `with` when the key when wasn't present.
+    ///
+    /// ```rust
+    /// use tremor_value::prelude::*;
+    /// let mut object = literal!({
+    ///   "answer": 23,
+    ///   "key": 7
+    /// });
+    /// let known_key = KnownKey::from("answer");
+    ///
+    /// assert_eq!(object["answer"], 23);
+    ///
+    /// if let Some(inner) = object.as_object_mut() {
+    ///   let answer = known_key.map_lookup_or_insert_mut(inner, || 17.into());
+    ///   assert_eq!(*answer, 23);
+    ///   *answer = Value::from(42);
+    /// }
+    ///
+    /// assert_eq!(object["answer"], 42);
+    ///
+    /// let known_key2 = KnownKey::from("also the answer");
+    /// if let Some(inner) = object.as_object_mut() {
+    ///   let answer = known_key2.map_lookup_or_insert_mut(inner, || 8.into());
+    ///   assert_eq!(*answer, 8);
+    ///   *answer = Value::from(42);
+    /// }
+    ///
+    /// assert_eq!(object["also the answer"], 42);
+    /// ```
+    #[inline]
+    pub fn map_lookup_or_insert_mut<'target, 'value, F>(
+        &self,
+        map: &'target mut halfbrown::HashMap<Cow<'value, str>, Value<'value>>,
+        with: F,
+    ) -> &'target mut Value<'value>
+    where
+        'key: 'value,
+        'value: 'target,
+        F: FnOnce() -> Value<'value>,
+    {
+        map.raw_entry_mut()
+            .from_key_hashed_nocheck(self.hash, &self.key)
+            .or_insert_with(|| (self.key.clone(), with()))
+            .1
     }
 
     /// Inserts a value key into  `Value`, returns None if the
@@ -215,22 +313,59 @@ impl<'key> KnownKey<'key> {
         'key: 'value,
         'value: 'target,
     {
-        if !target.is_object() {
-            return Err(Error::NotAnObject(target.value_type()));
-        }
+        target.as_object_mut()
+            .map(|m| self.map_insert(m, value))
+            .ok_or_else(|| Error::NotAnObject(target.value_type()))
+    }
 
-        Ok(target.as_object_mut().and_then(|m| {
-            match m
-                .raw_entry_mut()
-                .from_key_hashed_nocheck(self.hash, &self.key)
-            {
-                RawEntryMut::Occupied(mut e) => Some(e.insert(value)),
-                RawEntryMut::Vacant(e) => {
-                    e.insert_hashed_nocheck(self.hash, self.key.clone(), value);
-                    None
-                }
+    /// Inserts a value key into `map`, returns None if the
+    /// key wasn't present otherwise Some(`old value`).
+    ///
+    /// ```rust
+    /// use tremor_value::prelude::*;
+    ///
+    /// let mut object = literal!({
+    ///   "answer": 23,
+    ///   "key": 7
+    /// });
+    /// let known_key = KnownKey::from("answer");
+    ///
+    /// assert_eq!(object["answer"], 23);
+    ///
+    /// if let Some(inner) = object.as_object_mut() {
+    ///   assert!(known_key.map_insert(inner, Value::from(42)).is_some());
+    /// }
+    ///
+    /// assert_eq!(object["answer"], 42);
+    ///
+    /// let known_key2 = KnownKey::from("also the answer");
+    ///
+    /// if let Some(inner) = object.as_object_mut() {
+    ///   assert!(known_key2.map_insert(inner, Value::from(42)).is_none());
+    /// }
+    ///
+    /// assert_eq!(object["also the answer"], 42);
+    /// ```
+    #[inline]
+    pub fn map_insert<'target, 'value>(
+        &self,
+        map: &'target mut halfbrown::HashMap<Cow<'value, str>, Value<'value>>,
+        value: Value<'value>,
+    ) -> Option<Value<'value>>
+    where
+        'key: 'value,
+        'value: 'target,
+    {
+        match map
+            .raw_entry_mut()
+            .from_key_hashed_nocheck(self.hash, &self.key)
+        {
+            RawEntryMut::Occupied(mut e) => Some(e.insert(value)),
+            RawEntryMut::Vacant(e) => {
+                e.insert_hashed_nocheck(self.hash, self.key.clone(), value);
+                None
             }
-        }))
+        }
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -4,11 +4,11 @@
 /// allocate a new String for each value.
 ///
 /// Note that since json strings allow for for escape sequences the borrowed
-/// value does not impement zero copy parsing, it does however not allocate
+/// value does not implement zero copy parsing, it does however not allocate
 /// new memory for strings.
 ///
-/// This differs notably from serds zero copy implementation as, unlike serde,
-/// we do not require prior knowledge about string content to to take advantage
+/// This differs notably from serde's zero copy implementation as, unlike serde,
+/// we do not require prior knowledge about string content to take advantage
 /// of it.
 ///
 /// ## Usage


### PR DESCRIPTION
This is handy if you already know you have a `Value::Object(map)` in your hands, in which case we can spare a match on the enum variant.

This is a backport of what we did in https://github.com/tremor-rs/tremor-runtime/pull/969