### PR TITLE
aarch64: remove unused UTF-8 remnants causing build failures

### DIFF
--- a/src/neon/stage1.rs
+++ b/src/neon/stage1.rs
@@ -21,16 +21,6 @@ pub unsafe fn vtstq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
 }
 
 #[cfg_attr(not(feature = "no-inline"), inline(always))]
-pub(crate) unsafe fn neon_movemask(input: uint8x16_t) -> u16 {
-    let minput: uint8x16_t = vandq_u8(input, bit_mask());
-    let tmp: uint8x16_t = vpaddq_u8(minput, minput);
-    let tmp = vpaddq_u8(tmp, tmp);
-    let tmp = vpaddq_u8(tmp, tmp);
-
-    vgetq_lane_u16(vreinterpretq_u16_u8(tmp), 0)
-}
-
-#[cfg_attr(not(feature = "no-inline"), inline(always))]
 pub unsafe fn neon_movemask_bulk(
     p0: uint8x16_t,
     p1: uint8x16_t,
@@ -55,21 +45,6 @@ pub unsafe fn neon_movemask_bulk(
 
 pub const SIMDJSON_PADDING: usize = mem::size_of::<uint8x16_t>() * 4;
 pub const SIMDINPUT_LENGTH: usize = 64;
-
-#[cfg_attr(not(feature = "no-inline"), inline(always))]
-unsafe fn check_ascii(si: &SimdInput) -> bool {
-    let highbit: uint8x16_t = vdupq_n_u8(0x80);
-    let t0: uint8x16_t = vorrq_u8(si.v0, si.v1);
-    let t1: uint8x16_t = vorrq_u8(si.v2, si.v3);
-    let t3: uint8x16_t = vorrq_u8(t0, t1);
-    let t4: uint8x16_t = vandq_u8(t3, highbit);
-
-    let v64: uint64x2_t = vreinterpretq_u64_u8(t4);
-    let v32: uint32x2_t = vqmovn_u64(v64);
-    let result: uint64x1_t = vreinterpret_u64_u32(v32);
-
-    vget_lane_u64(result, 0) == 0
-}
 
 #[derive(Debug)]
 pub(crate) struct SimdInput {


### PR DESCRIPTION
simd-json still cannot build on aarch64 with nightly Rust despite https://github.com/rust-lang/stdarch/pull/1157 being fixed because the stdarch submodule in Rust has not been bumped yet.

Using a locally compiled Rust with bumped stdarch it compiles and runs the tests with the changes in this pull request. This just removes some dead code left over from the simdutf8 refactoring to make clippy happy.

Benchmarks on a MacBook Air:
```
group                                         base
-----                                         ----
apache_builds/simd_json::to_borrowed_value    1.00    179.3±0.98µs   676.8 MB/sec
apache_builds/simd_json::to_owned_value       1.00    491.1±5.14µs   247.2 MB/sec
apache_builds/simd_json::to_tape              1.00     58.4±0.65µs     2.0 GB/sec
canada/simd_json::to_borrowed_value           1.00      7.5±0.39ms   287.7 MB/sec
canada/simd_json::to_owned_value              1.00      7.3±0.33ms   292.7 MB/sec
canada/simd_json::to_tape                     1.00      2.9±0.07ms   734.8 MB/sec
citm_catalog/simd_json::to_borrowed_value     1.00      3.4±0.16ms   485.5 MB/sec
citm_catalog/simd_json::to_owned_value        1.00      5.3±0.13ms   308.6 MB/sec
citm_catalog/simd_json::to_tape               1.00  1238.0±192.26µs  1330.6 MB/sec
log/simd_json::to_borrowed_value              1.00      2.3±0.04µs   892.6 MB/sec
log/simd_json::to_owned_value                 1.00      7.9±0.17µs   263.2 MB/sec
log/simd_json::to_tape                        1.00  1471.5±26.32ns  1409.7 MB/sec
twitter/simd_json::to_borrowed_value          1.00   732.5±28.93µs   822.2 MB/sec
twitter/simd_json::to_owned_value             1.00  1960.6±31.81µs   307.2 MB/sec
twitter/simd_json::to_tape                    1.00   347.6±23.96µs  1732.5 MB/sec
```
In particular the core `to_tape`-performance is quite impressive.