### PR TITLE
Made the compatiblity check fail on absense of the `pclmulqdq`-feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simd-json"
-version = "0.4.7-alpha.0"
+version = "0.4.7-alpha.1"
 authors = ["Heinz N. Gies <heinz@licenser.net>", "Sunny Gleason"]
 edition = "2018"
 exclude = [ "data/*", "fuzz/*"]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 To be able to take advantage of `simd-json` your system needs to be SIMD capable. This means that it needs to compile with native cpu support and the given features. This also requires that projects using `simd-json` also need to be configured with native cpu support. Look at [The cargo config in this repository](.cargo/config) to get an example of how to configure this in your project.
 
-`simd-json` supports AVX2, SSE4.2 and NEON.
+`simd-json` supports AVX2, SSE4.2 and NEON. Both x86 backends (AVX2, SSE4.2) require your CPU to support [`pclmulqdq`](https://en.wikipedia.org/wiki/CLMUL_instruction_set) instructions.
 
 Unless the `allow-non-simd` feature is passed to your `simd-json` dependency in your `Cargo.toml` `simd-json` will fail to compile, this is to prevent unexpected slowness in fallback mode that can be hard to understand and hard to debug.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,8 +205,10 @@ use simdutf8::basic::imp::x86::sse42::ChunkedUtf8ValidatorImp;
 #[cfg(all(
     not(feature = "allow-non-simd"),
     not(any(
-        target_feature = "sse4.2",
-        target_feature = "avx2",
+        all(
+            any(target_feature = "sse4.2", target_feature = "avx2"),
+            target_feature = "pclmulqdq"
+        ),
         target_feature = "neon"
     ))
 ))]


### PR DESCRIPTION
Preventing the library from producing invalid code on some machines (See #200)