### PR TITLE
Added fallback function for CPUs that don't support pclmulqdq instructions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,6 +13,7 @@ jobs:
         rustflags:
           - '-C target-cpu=native'
           - '-C target-cpu=native -C target-feature=-avx2'
+          - '-C target-cpu=native -C target-feature=-avx2,-pclmulqdq'
         features:
           - ''
           - '--features known-key'

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -9,6 +9,7 @@ jobs:
         rustflags:
           - "-C target-cpu=native"
           - "-C target-cpu=native -C target-feature=-avx2"
+          - "-C target-cpu=native -C target-feature=-avx2,-pclmulqdq"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -32,6 +33,7 @@ jobs:
         rustflags:
           - ""
           - "-C target-feature=-avx2"
+          - "-C target-feature=-avx2,-pclmulqdq"
         features:
           - ",known-key,128bit,beef"
           - ",known-key,beef"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
         rustflags:
           - '-C target-cpu=native'
           - '-C target-cpu=native -C target-feature=-avx2'
+          - '-C target-cpu=native -C target-feature=-avx2,-pclmulqdq'
         features:
           - '--no-default-features'
           - ''

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simd-json"
-version = "0.4.7-alpha.0"
+version = "0.4.7-alpha.1"
 authors = ["Heinz N. Gies <heinz@licenser.net>", "Sunny Gleason"]
 edition = "2018"
 exclude = [ "data/*", "fuzz/*"]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 To be able to take advantage of `simd-json` your system needs to be SIMD capable. This means that it needs to compile with native cpu support and the given features. This also requires that projects using `simd-json` also need to be configured with native cpu support. Look at [The cargo config in this repository](.cargo/config) to get an example of how to configure this in your project.
 
-`simd-json` supports AVX2, SSE4.2 and NEON. Both x86 backends (AVX2, SSE4.2) require your CPU to support [`pclmulqdq`](https://en.wikipedia.org/wiki/CLMUL_instruction_set) instructions.
+`simd-json` supports AVX2, SSE4.2 and NEON.
 
 Unless the `allow-non-simd` feature is passed to your `simd-json` dependency in your `Cargo.toml` `simd-json` will fail to compile, this is to prevent unexpected slowness in fallback mode that can be hard to understand and hard to debug.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 To be able to take advantage of `simd-json` your system needs to be SIMD capable. This means that it needs to compile with native cpu support and the given features. This also requires that projects using `simd-json` also need to be configured with native cpu support. Look at [The cargo config in this repository](.cargo/config) to get an example of how to configure this in your project.
 
-`simd-json` supports AVX2, SSE4.2 and NEON.
+`simd-json` supports AVX2, SSE4.2 and NEON. Both x86 backends (AVX2, SSE4.2) require your CPU to support [`pclmulqdq`](https://en.wikipedia.org/wiki/CLMUL_instruction_set) instructions.
 
 Unless the `allow-non-simd` feature is passed to your `simd-json` dependency in your `Cargo.toml` `simd-json` will fail to compile, this is to prevent unexpected slowness in fallback mode that can be hard to understand and hard to debug.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,8 +205,10 @@ use simdutf8::basic::imp::x86::sse42::ChunkedUtf8ValidatorImp;
 #[cfg(all(
     not(feature = "allow-non-simd"),
     not(any(
-        target_feature = "sse4.2",
-        target_feature = "avx2",
+        all(
+            any(target_feature = "sse4.2", target_feature = "avx2"),
+            target_feature = "pclmulqdq"
+        ),
         target_feature = "neon"
     ))
 ))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,10 +205,8 @@ use simdutf8::basic::imp::x86::sse42::ChunkedUtf8ValidatorImp;
 #[cfg(all(
     not(feature = "allow-non-simd"),
     not(any(
-        all(
-            any(target_feature = "sse4.2", target_feature = "avx2"),
-            target_feature = "pclmulqdq"
-        ),
+        target_feature = "sse4.2",
+        target_feature = "avx2",
         target_feature = "neon"
     ))
 ))]

--- a/src/sse42/stage1.rs
+++ b/src/sse42/stage1.rs
@@ -1,16 +1,15 @@
 use crate::{static_cast_i32, static_cast_u32, Stage1Parse};
 #[cfg(target_arch = "x86")]
 use std::arch::x86::{
-    __m128i, _mm_add_epi32, _mm_and_si128, _mm_cmpeq_epi8, _mm_cmpgt_epi8,
-    _mm_loadu_si128, _mm_max_epu8, _mm_movemask_epi8, _mm_or_si128,
-    _mm_set1_epi8, _mm_set_epi32, _mm_setr_epi8, _mm_setzero_si128,
-    _mm_shuffle_epi8, _mm_srli_epi32, _mm_storeu_si128, _mm_testz_si128,
+    __m128i, _mm_add_epi32, _mm_and_si128, _mm_cmpeq_epi8, _mm_cmpgt_epi8, _mm_loadu_si128,
+    _mm_max_epu8, _mm_movemask_epi8, _mm_or_si128, _mm_set1_epi8, _mm_set_epi32, _mm_setr_epi8,
+    _mm_setzero_si128, _mm_shuffle_epi8, _mm_srli_epi32, _mm_storeu_si128, _mm_testz_si128,
 };
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::{
-    __m128i, _mm_add_epi32, _mm_and_si128, _mm_cmpeq_epi8,
-    _mm_loadu_si128, _mm_max_epu8, _mm_movemask_epi8, _mm_set1_epi8, _mm_set_epi32,
-    _mm_setr_epi8, _mm_setzero_si128, _mm_shuffle_epi8, _mm_srli_epi32, _mm_storeu_si128,
+    __m128i, _mm_add_epi32, _mm_and_si128, _mm_cmpeq_epi8, _mm_loadu_si128, _mm_max_epu8,
+    _mm_movemask_epi8, _mm_set1_epi8, _mm_set_epi32, _mm_setr_epi8, _mm_setzero_si128,
+    _mm_shuffle_epi8, _mm_srli_epi32, _mm_storeu_si128,
 };
 
 use std::mem;
@@ -59,13 +58,9 @@ impl Stage1Parse<__m128i> for SimdInput {
     #[allow(clippy::cast_sign_loss)]
     fn compute_quote_mask(quote_bits: u64) -> u64 {
         #[cfg(target_arch = "x86")]
-        use std::arch::x86::{
-            _mm_cvtsi128_si64, _mm_clmulepi64_si128, _mm_set_epi64x
-        };
+        use std::arch::x86::{_mm_clmulepi64_si128, _mm_cvtsi128_si64, _mm_set_epi64x};
         #[cfg(target_arch = "x86_64")]
-        use std::arch::x86_64::{
-            _mm_cvtsi128_si64, _mm_clmulepi64_si128, _mm_set_epi64x
-        };
+        use std::arch::x86_64::{_mm_clmulepi64_si128, _mm_cvtsi128_si64, _mm_set_epi64x};
 
         unsafe {
             _mm_cvtsi128_si64(_mm_clmulepi64_si128(

--- a/src/sse42/stage1.rs
+++ b/src/sse42/stage1.rs
@@ -1,15 +1,15 @@
-use crate::{static_cast_i32, static_cast_i64, static_cast_u32, Stage1Parse};
+use crate::{static_cast_i32, static_cast_u32, Stage1Parse};
 #[cfg(target_arch = "x86")]
 use std::arch::x86::{
-    __m128i, _mm_add_epi32, _mm_and_si128, _mm_clmulepi64_si128, _mm_cmpeq_epi8, _mm_cmpgt_epi8,
-    _mm_cvtsi128_si64, _mm_loadu_si128, _mm_max_epu8, _mm_movemask_epi8, _mm_or_si128,
-    _mm_set1_epi8, _mm_set_epi32, _mm_set_epi64x, _mm_setr_epi8, _mm_setzero_si128,
+    __m128i, _mm_add_epi32, _mm_and_si128, _mm_cmpeq_epi8, _mm_cmpgt_epi8,
+    _mm_loadu_si128, _mm_max_epu8, _mm_movemask_epi8, _mm_or_si128,
+    _mm_set1_epi8, _mm_set_epi32, _mm_setr_epi8, _mm_setzero_si128,
     _mm_shuffle_epi8, _mm_srli_epi32, _mm_storeu_si128, _mm_testz_si128,
 };
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::{
-    __m128i, _mm_add_epi32, _mm_and_si128, _mm_clmulepi64_si128, _mm_cmpeq_epi8, _mm_cvtsi128_si64,
-    _mm_loadu_si128, _mm_max_epu8, _mm_movemask_epi8, _mm_set1_epi8, _mm_set_epi32, _mm_set_epi64x,
+    __m128i, _mm_add_epi32, _mm_and_si128, _mm_cmpeq_epi8,
+    _mm_loadu_si128, _mm_max_epu8, _mm_movemask_epi8, _mm_set1_epi8, _mm_set_epi32,
     _mm_setr_epi8, _mm_setzero_si128, _mm_shuffle_epi8, _mm_srli_epi32, _mm_storeu_si128,
 };
 
@@ -55,8 +55,18 @@ impl SimdInput {
 
 impl Stage1Parse<__m128i> for SimdInput {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
+    #[cfg(target_feature = "pclmulqdq")]
     #[allow(clippy::cast_sign_loss)]
     fn compute_quote_mask(quote_bits: u64) -> u64 {
+        #[cfg(target_arch = "x86")]
+        use std::arch::x86::{
+            _mm_cvtsi128_si64, _mm_clmulepi64_si128, _mm_set_epi64x
+        };
+        #[cfg(target_arch = "x86_64")]
+        use std::arch::x86_64::{
+            _mm_cvtsi128_si64, _mm_clmulepi64_si128, _mm_set_epi64x
+        };
+
         unsafe {
             _mm_cvtsi128_si64(_mm_clmulepi64_si128(
                 _mm_set_epi64x(0, static_cast_i64!(quote_bits)),
@@ -64,6 +74,19 @@ impl Stage1Parse<__m128i> for SimdInput {
                 0,
             )) as u64
         }
+    }
+
+    #[cfg(not(target_feature = "pclmulqdq"))]
+    fn compute_quote_mask(mut quote_bits: u64) -> u64 {
+        let b = -1i64 as u64;
+        let mut prod = 0;
+
+        while quote_bits != 0 {
+            prod ^= b.wrapping_mul(quote_bits & 0u64.wrapping_sub(quote_bits));
+            quote_bits &= quote_bits.wrapping_sub(1);
+        }
+
+        return prod;
     }
 
     /// a straightforward comparison of a mask against input


### PR DESCRIPTION
I was unable to create a faster function with SIMD instructions, primarily because x86 has no 64-bit vector multiply instruction. 

On my machine, the fallback function makes the parsing ~10% slower

Fixes #202