### PR TITLE
fix typos

### DIFF
--- a/examples/perf.rs
+++ b/examples/perf.rs
@@ -175,7 +175,7 @@ mod int {
             let r = simd_json::to_borrowed_value(&mut bytes);
             // Stop counters
             stats.stop(pc);
-            // we make sure that dropping doesn't happen untill we are done with our counting.
+            // we make sure that dropping doesn't happen until we are done with our counting.
             // better safe then sorry.
             assert!(r.is_ok());
             // do our accounting

--- a/src/avx2/deser.rs
+++ b/src/avx2/deser.rs
@@ -34,7 +34,7 @@ impl<'de> Deserializer<'de> {
         buffer: &'invoke mut [u8],
         mut idx: usize,
     ) -> Result<&'de str> {
-        use ErrorType::{InvalidEscape, InvlaidUnicodeCodepoint};
+        use ErrorType::{InvalidEscape, InvalidUnicodeCodepoint};
         let input: &mut [u8] = unsafe { std::mem::transmute(input) };
         // Add 1 to skip the initial "
         idx += 1;
@@ -168,10 +168,10 @@ impl<'de> Deserializer<'de> {
                         }) {
                         r
                     } else {
-                        return Err(Self::raw_error(src_i, 'u', InvlaidUnicodeCodepoint));
+                        return Err(Self::raw_error(src_i, 'u', InvalidUnicodeCodepoint));
                     };
                     if o == 0 {
-                        return Err(Self::raw_error(src_i, 'u', InvlaidUnicodeCodepoint));
+                        return Err(Self::raw_error(src_i, 'u', InvalidUnicodeCodepoint));
                     };
                     // We moved o steps forward at the destination and 6 on the source
                     src_i += s;

--- a/src/avx2/deser.rs
+++ b/src/avx2/deser.rs
@@ -41,7 +41,7 @@ impl<'de> Deserializer<'de> {
         //let mut read: usize = 0;
 
         // we include the terminal '"' so we know where to end
-        // This is safe since we check sub's lenght in the range access above and only
+        // This is safe since we check sub's length in the range access above and only
         // create sub sliced form sub to `sub.len()`.
 
         let src: &[u8] = unsafe { data.get_unchecked(idx..) };
@@ -173,7 +173,7 @@ impl<'de> Deserializer<'de> {
                     if o == 0 {
                         return Err(Self::raw_error(src_i, 'u', InvlaidUnicodeCodepoint));
                     };
-                    // We moved o steps forword at the destiation and 6 on the source
+                    // We moved o steps forward at the destination and 6 on the source
                     src_i += s;
                     dst_i += o;
                 } else {

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,12 +48,12 @@ pub enum ErrorType {
     InvalidExponent,
     /// Invalid number
     InvalidNumber,
-    /// Inbalid UTF8 codepoint
+    /// Invalid UTF8 codepoint
     InvalidUtf8,
     /// Invalid Unicode escape sequence
     InvalidUnicodeEscape,
-    /// Inbalid Unicode codepoint
-    InvlaidUnicodeCodepoint,
+    /// Invalid Unicode codepoint
+    InvalidUnicodeCodepoint,
     /// Object Key isn't a string
     KeyMustBeAString,
     /// Non structural character
@@ -121,7 +121,7 @@ impl PartialEq for ErrorType {
             | (Self::InvalidNumber, Self::InvalidNumber)
             | (Self::InvalidUtf8, Self::InvalidUtf8)
             | (Self::InvalidUnicodeEscape, Self::InvalidUnicodeEscape)
-            | (Self::InvlaidUnicodeCodepoint, Self::InvlaidUnicodeCodepoint)
+            | (Self::InvalidUnicodeCodepoint, Self::InvalidUnicodeCodepoint)
             | (Self::KeyMustBeAString, Self::KeyMustBeAString)
             | (Self::NoStructure, Self::NoStructure)
             | (Self::Parser, Self::Parser)

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,7 @@ pub enum ErrorType {
     ExpectedInteger,
     /// Expected a map
     ExpectedMap,
-    /// Expected an `:` to seperate key and value in an object
+    /// Expected an `:` to separate key and value in an object
     ExpectedObjectColon,
     /// Expected a `,` in an object
     ExpectedMapComma,
@@ -58,7 +58,7 @@ pub enum ErrorType {
     KeyMustBeAString,
     /// Non structural character
     NoStructure,
-    /// Parser Erropr
+    /// Parser Error
     Parser,
     /// Early End Of File
     Eof,
@@ -147,7 +147,7 @@ pub struct Error {
     index: usize,
     /// Current character
     character: char,
-    /// Tyep of error
+    /// Type of error
     error: ErrorType,
 }
 

--- a/src/known_key.rs
+++ b/src/known_key.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::hash::{BuildHasher, Hash, Hasher};
 
 /// Well known key that can be looked up in a `Value` faster.
-/// It achives this by memorizing the hash.
+/// It achieves this by memorizing the hash.
 #[derive(Debug, Clone, PartialEq)]
 pub struct KnownKey<'key> {
     key: Cow<'key, str>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 //!
 //! Compatibility with [serde](https://serde.rs/). This allows to use
 //! [simd-json.rs](https://simd-json.rs) to deserialize serde objects
-//! as well as serd compatibility of the different Value types.
+//! as well as serde compatibility of the different Value types.
 //! This can be disabled if serde is not used alongside simd-json.
 //!
 //! ### `128bit`
@@ -816,7 +816,7 @@ mod tests {
         let v = Value::from(-6.990_585_694_841_803e305);
         let s = v.encode();
         let mut bytes = s.as_bytes().to_vec();
-        let parsed = to_owned_value(&mut bytes).expect("failed to parse gernated float");
+        let parsed = to_owned_value(&mut bytes).expect("failed to parse generated float");
         assert_eq!(v, parsed);
     }
     #[cfg(not(feature = "128bit"))]
@@ -1404,7 +1404,7 @@ mod tests_serde {
         assert_eq!(v_simd, v_serde)
     }
 
-    // We ignore this since serde is less percise on this test
+    // We ignore this since serde is less precise on this test
     #[ignore]
     #[test]
     fn float2() {

--- a/src/neon/deser.rs
+++ b/src/neon/deser.rs
@@ -173,10 +173,10 @@ impl<'de> Deserializer<'de> {
                         }) {
                         r
                     } else {
-                        return Err(Self::raw_error(src_i, 'u', InvlaidUnicodeCodepoint));
+                        return Err(Self::raw_error(src_i, 'u', InvalidUnicodeCodepoint));
                     };
                     if o == 0 {
-                        return Err(Self::raw_error(src_i, 'u', InvlaidUnicodeCodepoint));
+                        return Err(Self::raw_error(src_i, 'u', InvalidUnicodeCodepoint));
                     };
                     // We moved o steps forward at the destination and 6 on the source
                     src_i += s;

--- a/src/neon/deser.rs
+++ b/src/neon/deser.rs
@@ -58,7 +58,7 @@ impl<'de> Deserializer<'de> {
         //let mut read: usize = 0;
 
         // we include the terminal '"' so we know where to end
-        // This is safe since we check sub's lenght in the range access above and only
+        // This is safe since we check sub's length in the range access above and only
         // create sub sliced form sub to `sub.len()`.
 
         let src: &[u8] = unsafe { data.get_unchecked(idx..) };
@@ -178,7 +178,7 @@ impl<'de> Deserializer<'de> {
                     if o == 0 {
                         return Err(Self::raw_error(src_i, 'u', InvlaidUnicodeCodepoint));
                     };
-                    // We moved o steps forword at the destiation and 6 on the source
+                    // We moved o steps forward at the destination and 6 on the source
                     src_i += s;
                     dst_i += o;
                 } else {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -4,7 +4,7 @@
 /// better performance.
 ///
 /// However if have to use serde for other reasons or are parsing
-/// directly to structs this is th4 place to go.
+/// directly to structs this is the place to go.
 ///
 mod de;
 mod se;
@@ -83,7 +83,7 @@ where
 ///
 /// # Errors
 ///
-/// Will return `Err` if an IO error is encountred while reading
+/// Will return `Err` if an IO error is encountered while reading
 /// rdr or if the readers content is invalid JSON.
 #[cfg_attr(not(feature = "no-inline"), inline(always))]
 pub fn from_reader<R, T>(mut rdr: R) -> Result<T>

--- a/src/serde/se.rs
+++ b/src/serde/se.rs
@@ -826,7 +826,7 @@ mod test {
     use proptest::prelude::*;
 
     #[test]
-    fn prety_print_serde() {
+    fn pretty_print_serde() {
         #[derive(Clone, Debug, PartialEq, serde::Serialize)]
         enum Segment {
             Id { mid: usize },

--- a/src/serde/value/borrowed/se.rs
+++ b/src/serde/value/borrowed/se.rs
@@ -842,11 +842,11 @@ mod test {
             let de: Obj = from_slice(&mut vec).expect("from_slice");
             prop_assert_eq!(&obj, &de);
 
-            let borroed: crate::BorrowedValue = serde_json::from_slice(& vec1).expect("from_slice");
+            let borrowed: crate::BorrowedValue = serde_json::from_slice(& vec1).expect("from_slice");
             let owned: crate::OwnedValue = serde_json::from_slice(& vec2).expect("from_slice");
-            prop_assert_eq!(&borroed, &owned);
+            prop_assert_eq!(&borrowed, &owned);
 
-            let de: Obj = Obj::deserialize(borroed).expect("deserialize");
+            let de: Obj = Obj::deserialize(borrowed).expect("deserialize");
             prop_assert_eq!(&obj, &de);
             let de: Obj = Obj::deserialize(owned).expect("deserialize");
             prop_assert_eq!(&obj, &de);

--- a/src/serde/value/owned/se.rs
+++ b/src/serde/value/owned/se.rs
@@ -762,11 +762,11 @@ mod test {
             let de: Obj = from_slice(&mut vec).expect("from_slice");
             prop_assert_eq!(&obj, &de);
 
-            let borroed: crate::BorrowedValue = serde_json::from_slice(& vec1).expect("from_slice");
+            let borrowed: crate::BorrowedValue = serde_json::from_slice(& vec1).expect("from_slice");
             let owned: crate::OwnedValue = serde_json::from_slice(& vec2).expect("from_slice");
-            prop_assert_eq!(&borroed, &owned);
+            prop_assert_eq!(&borrowed, &owned);
 
-            let de: Obj = Obj::deserialize(borroed).expect("deserialize");
+            let de: Obj = Obj::deserialize(borrowed).expect("deserialize");
             prop_assert_eq!(&obj, &de);
             let de: Obj = Obj::deserialize(owned).expect("deserialize");
             prop_assert_eq!(&obj, &de);

--- a/src/sse42/deser.rs
+++ b/src/sse42/deser.rs
@@ -30,7 +30,7 @@ impl<'de> Deserializer<'de> {
         buffer: &'invoke mut [u8],
         mut idx: usize,
     ) -> Result<&'de str> {
-        use ErrorType::{InvalidEscape, InvlaidUnicodeCodepoint};
+        use ErrorType::{InvalidEscape, InvalidUnicodeCodepoint};
         let input: &mut [u8] = unsafe { std::mem::transmute(input) };
         // Add 1 to skip the initial "
         idx += 1;
@@ -163,10 +163,10 @@ impl<'de> Deserializer<'de> {
                         }) {
                         r
                     } else {
-                        return Err(Self::raw_error(src_i, 'u', InvlaidUnicodeCodepoint));
+                        return Err(Self::raw_error(src_i, 'u', InvalidUnicodeCodepoint));
                     };
                     if o == 0 {
-                        return Err(Self::raw_error(src_i, 'u', InvlaidUnicodeCodepoint));
+                        return Err(Self::raw_error(src_i, 'u', InvalidUnicodeCodepoint));
                     };
                     // We moved o steps forward at the destination and 6 on the source
                     src_i += s;

--- a/src/sse42/deser.rs
+++ b/src/sse42/deser.rs
@@ -36,7 +36,7 @@ impl<'de> Deserializer<'de> {
         idx += 1;
 
         // we include the terminal '"' so we know where to end
-        // This is safe since we check sub's lenght in the range access above and only
+        // This is safe since we check sub's length in the range access above and only
         // create sub sliced form sub to `sub.len()`.
 
         let src: &[u8] = unsafe { data.get_unchecked(idx..) };
@@ -168,7 +168,7 @@ impl<'de> Deserializer<'de> {
                     if o == 0 {
                         return Err(Self::raw_error(src_i, 'u', InvlaidUnicodeCodepoint));
                     };
-                    // We moved o steps forword at the destiation and 6 on the source
+                    // We moved o steps forward at the destination and 6 on the source
                     src_i += s;
                     dst_i += o;
                 } else {

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -69,9 +69,9 @@ pub fn is_valid_false_atom(loc: &[u8]) -> bool {
 
         // FIXME the original code looks like this:
         // error = ((locval & mask5) ^ fv) as u32;
-        // but that failes on falsy as the u32 conversion
+        // but that fails on falsy as the u32 conversion
         // will mask the error on the y so we re-write it
-        // it would be interesting what the consequecnes are
+        // it would be interesting what the consequences are
         error = (locval & MASK5) ^ FV;
         error |= u64::from(is_not_structural_or_whitespace(*get!(loc, 5)));
     }
@@ -118,7 +118,7 @@ impl<'de> Deserializer<'de> {
         structural_indexes: &[u32],
     ) -> Result<Vec<Node<'de>>> {
         // While a valid json can have at max len/2 (`[[[]]]`)elements that are relevant
-        // a invalid json might exceed this `[[[[[[` and we need to pretect against that.
+        // a invalid json might exceed this `[[[[[[` and we need to protect against that.
         let mut res: Vec<Node<'de>> = Vec::with_capacity(structural_indexes.len());
         let mut stack = Vec::with_capacity(structural_indexes.len());
         unsafe {
@@ -146,7 +146,7 @@ impl<'de> Deserializer<'de> {
                 match $e {
                     ::std::result::Result::Ok(val) => val,
                     ::std::result::Result::Err(err) => {
-                        // We need to ensure that rust doens't
+                        // We need to ensure that rust doesn't
                         // try to free strings that we never
                         // allocated
                         unsafe {
@@ -280,7 +280,7 @@ impl<'de> Deserializer<'de> {
 
         macro_rules! fail {
             () => {
-                // We need to ensure that rust doens't
+                // We need to ensure that rust doesn't
                 // try to free strings that we never
                 // allocated
                 unsafe {
@@ -289,7 +289,7 @@ impl<'de> Deserializer<'de> {
                 return Err(Error::new(idx, c as char, ErrorType::InternalError));
             };
             ($t:expr) => {
-                // We need to ensure that rust doens't
+                // We need to ensure that rust doesn't
                 // try to free strings that we never
                 // allocated
                 unsafe {
@@ -299,7 +299,7 @@ impl<'de> Deserializer<'de> {
             };
         }
         // State start, we pull this outside of the
-        // loop to reduce the number of requried checks
+        // loop to reduce the number of required checks
         update_char!();
         match c {
             b'{' => {

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,13 +1,13 @@
-/// This module holds the two dom implementations we use. We distingush between
+/// This module holds the two dom implementations we use. We distinguish between
 /// owned and borrowed. The difference being is that the borrowed value will
-/// use `&str` as its string type, refferencing the input, while owned will
+/// use `&str` as its string type, referencing the input, while owned will
 /// allocate a new String for each value.
 ///
 /// Note that since json strings allow for for escape sequences the borrowed
-/// value does not impement zero copy parsing, it does however not allocate
+/// value does not implement zero copy parsing, it does however not allocate
 /// new memory for strings.
 ///
-/// This differs notably from serds zero copy implementation as, unlike serde,
+/// This differs notably from serde's zero copy implementation as, unlike serde,
 /// we do not require prior knowledge about string content to to take advantage
 /// of it.
 ///
@@ -71,7 +71,7 @@ use std::marker::PhantomData;
 use tape::Node;
 pub use value_trait::*;
 
-/// Parses a slice of butes into a Value dom. This function will
+/// Parses a slice of bytes into a Value dom. This function will
 /// rewrite the slice to de-escape strings.
 /// As we reference parts of the input slice the resulting dom
 /// has the same lifetime as the slice it was created from.
@@ -123,8 +123,8 @@ where
 
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     fn parse_array(&mut self, len: usize) -> Value {
-        // Rust doens't optimize the normal loop away here
-        // so we write our own avoiding the lenght
+        // Rust doesn't optimize the normal loop away here
+        // so we write our own avoiding the length
         // checks during push
         let mut res = Vec::with_capacity(len);
         unsafe {

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -377,8 +377,8 @@ impl<'de> BorrowDeserializer<'de> {
 
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     fn parse_array(&mut self, len: usize) -> Value<'de> {
-        // Rust doens't optimize the normal loop away here
-        // so we write our own avoiding the lenght
+        // Rust doesn't optimize the normal loop away here
+        // so we write our own avoiding the length
         // checks during push
         let mut res = Vec::with_capacity(len);
         unsafe {

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -52,7 +52,7 @@ pub fn to_value(s: &mut [u8]) -> Result<Value> {
 /// Parses a slice of bytes into a Value dom. This function will
 /// rewrite the slice to de-escape strings.
 /// We do not keep any references to the raw data but re-allocate
-/// owned memory whereever required thus returning a value without
+/// owned memory wherever required thus returning a value without
 /// a lifetime.
 ///
 /// # Errors
@@ -315,8 +315,8 @@ impl<'de> OwnedDeserializer<'de> {
 
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     fn parse_array(&mut self, len: usize) -> Value {
-        // Rust doens't optimize the normal loop away here
-        // so we write our own avoiding the lenght
+        // Rust doesn't optimize the normal loop away here
+        // so we write our own avoiding the length
         // checks during push
         let mut res = Vec::with_capacity(len);
         unsafe {

--- a/src/value/owned/serialize.rs
+++ b/src/value/owned/serialize.rs
@@ -1,5 +1,5 @@
 // This is mostly taken from json-rust's codegen
-// as it seems to perform well and it makes snense to see
+// as it seems to perform well and it makes sense to see
 // if we can adopt the approach
 //
 // https://github.com/maciejhirsz/json-rust/blob/master/src/codegen.rs


### PR DESCRIPTION
Here's a PR to fix some typos I found in the code.

There's also a typo on the ErrorType struct : https://github.com/simd-lite/simd-json/blob/main/src/error.rs#L56 but fixing it will be a breaking change