### PR TITLE
feat(arch): add support for wasm32 with simd128 feature

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,8 @@
 [build]
 rustflags = ["-C", "target-cpu=native"]
+
+[target.wasm32-unknown-unknown]
+rustflags = ["-C", "target-feature=+simd128"]
+
+[target.wasm32-wasi]
+rustflags = ["-C", "target-feature=+simd128"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ rust-version = "1.49"
 [dependencies]
 beef = { version = "0.5", optional = true }
 halfbrown = "0.1"
-value-trait = { version = "0.2.1" }
-simdutf8 = { version = "0.1.3", features = ["public_imp", "aarch64_neon"] }
+value-trait = "0.2.10"
+simdutf8 = { version = "0.1.4", features = ["public_imp", "aarch64_neon"] }
 
 # serde compatibilty
 serde = { version = "1", features = ["derive"], optional = true}
@@ -35,6 +35,8 @@ criterion = { version = "0.3", optional = true }
 [dev-dependencies]
 float-cmp = "0.9"
 getopts = "0.2"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 proptest = "1.0"
 
 [lib]

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,8 @@ perf:
 clippy:
 	touch src/lib.rs
 	cargo clippy
+wasmtest:
+	cargo clean --target-dir target
+	cargo build --tests --target wasm32-wasi --target-dir target
+	wasmtime run --wasm-features=simd target/wasm32-wasi/debug/deps/simd_json*.wasm
+	wasmtime run --dir=. --wasm-features=simd target/wasm32-wasi/debug/deps/jsonchecker*.wasm

--- a/src/neon/stage1.rs
+++ b/src/neon/stage1.rs
@@ -11,15 +11,6 @@ pub(crate) unsafe fn bit_mask() -> uint8x16_t {
     ])
 }
 
-// FIXME this needs to be upstream
-//
-// vtstq_u8
-// vmovq_n_s8
-
-pub unsafe fn vtstq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
-    vcgtq_u8(vandq_u8(a, b), vdupq_n_u8(0))
-}
-
 #[cfg_attr(not(feature = "no-inline"), inline(always))]
 pub unsafe fn neon_movemask_bulk(
     p0: uint8x16_t,

--- a/src/numberparse.rs
+++ b/src/numberparse.rs
@@ -160,7 +160,7 @@ fn parse_eight_digits_unrolled(chars: &[u8]) -> u32 {
 }
 
 #[cfg_attr(not(feature = "no-inline"), inline)]
-#[cfg(target_feature = "neon")]
+#[cfg(any(target_feature = "neon", target_feature = "simd128"))]
 fn parse_eight_digits_unrolled(chars: &[u8]) -> u32 {
     let val: u64 = unsafe { *(chars.as_ptr() as *const u64) };
     //    memcpy(&val, chars, sizeof(u64));

--- a/src/serde/se.rs
+++ b/src/serde/se.rs
@@ -820,7 +820,9 @@ where
 
 #[cfg(test)]
 mod test {
+    #[cfg(not(target_arch = "wasm32"))]
     use crate::{OwnedValue as Value, StaticNode};
+    #[cfg(not(target_arch = "wasm32"))]
     use proptest::prelude::*;
 
     #[test]
@@ -871,6 +873,7 @@ mod test {
     }
 
     #[cfg(not(feature = "128bit"))]
+    #[cfg(not(target_arch = "wasm32"))]
     fn arb_json_value() -> BoxedStrategy<Value> {
         let leaf = prop_oneof![
             Just(Value::Static(StaticNode::Null)),
@@ -902,6 +905,7 @@ mod test {
     }
 
     #[cfg(feature = "128bit")]
+    #[cfg(not(target_arch = "wasm32"))]
     fn arb_json_value() -> BoxedStrategy<Value> {
         let leaf = prop_oneof![
             Just(Value::Static(StaticNode::Null)),
@@ -934,6 +938,7 @@ mod test {
         .boxed()
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     proptest! {
         #![proptest_config(ProptestConfig {
             // Setting both fork and timeout is redundant since timeout implies

--- a/src/serde/se/pp.rs
+++ b/src/serde/se/pp.rs
@@ -651,10 +651,13 @@ where
 
 #[cfg(test)]
 mod test {
+    #[cfg(not(target_arch = "wasm32"))]
     use crate::{OwnedValue as Value, StaticNode};
+    #[cfg(not(target_arch = "wasm32"))]
     use proptest::prelude::*;
 
     #[cfg(not(feature = "128bit"))]
+    #[cfg(not(target_arch = "wasm32"))]
     fn arb_json_value() -> BoxedStrategy<Value> {
         let leaf = prop_oneof![
             Just(Value::Static(StaticNode::Null)),
@@ -686,6 +689,7 @@ mod test {
     }
 
     #[cfg(feature = "128bit")]
+    #[cfg(not(target_arch = "wasm32"))]
     fn arb_json_value() -> BoxedStrategy<Value> {
         let leaf = prop_oneof![
             Just(Value::Static(StaticNode::Null)),
@@ -718,6 +722,7 @@ mod test {
         .boxed()
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     proptest! {
         #![proptest_config(ProptestConfig {
             // Setting both fork and timeout is redundant since timeout implies

--- a/src/serde/value/borrowed/se.rs
+++ b/src/serde/value/borrowed/se.rs
@@ -793,7 +793,9 @@ mod test {
         assert_eq!(vec, vec3);
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     use proptest::prelude::*;
+    #[cfg(not(target_arch = "wasm32"))]
     prop_compose! {
       fn obj_case()(
         v_i128 in any::<i64>().prop_map(i128::from),
@@ -831,6 +833,7 @@ mod test {
       }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     proptest! {
         #![proptest_config(ProptestConfig {
             .. ProptestConfig::default()

--- a/src/serde/value/owned/se.rs
+++ b/src/serde/value/owned/se.rs
@@ -642,7 +642,9 @@ impl serde::ser::SerializeStructVariant for SerializeStructVariant {
 
 #[cfg(test)]
 mod test {
-    use crate::serde::{from_slice, from_str, to_string};
+    use crate::serde::from_slice;
+    #[cfg(not(target_arch = "wasm32"))]
+    use crate::serde::{from_str, to_string};
     /*
     use crate::{
         owned::to_value, owned::Object, owned::Value, to_borrowed_value, to_owned_value,
@@ -729,7 +731,9 @@ mod test {
         assert_eq!(vec, vec3);
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     use proptest::prelude::*;
+    #[cfg(not(target_arch = "wasm32"))]
     prop_compose! {
       fn obj_case()(
         v_i128 in any::<i64>().prop_map(i128::from),
@@ -775,6 +779,7 @@ mod test {
       }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     proptest! {
         #![proptest_config(ProptestConfig {
             .. ProptestConfig::default()

--- a/src/simd128/deser.rs
+++ b/src/simd128/deser.rs
@@ -1,0 +1,168 @@
+use std::arch::wasm32::{u8x16_bitmask, u8x16_eq, u8x16_splat, v128, v128_load, v128_store};
+
+pub use crate::{
+    error::{Error, ErrorType},
+    Result,
+};
+use crate::{
+    stringparse::{handle_unicode_codepoint, ESCAPE_MAP},
+    Deserializer,
+};
+
+impl<'de> Deserializer<'de> {
+    #[allow(
+        clippy::if_not_else,
+        mutable_transmutes,
+        clippy::transmute_ptr_to_ptr,
+        clippy::cast_ptr_alignment,
+        clippy::cast_possible_wrap,
+        clippy::too_many_lines
+    )]
+    #[cfg_attr(not(feature = "no-inline"), inline(always))]
+    pub(crate) fn parse_str_<'invoke>(
+        input: &'de [u8],
+        data: &'invoke [u8],
+        buffer: &'invoke mut [u8],
+        mut idx: usize,
+    ) -> Result<&'de str> {
+        use ErrorType::{InvalidEscape, InvalidUnicodeCodepoint};
+        let input: &mut [u8] = unsafe { std::mem::transmute(input) };
+        // Add 1 to skip the initial "
+        idx += 1;
+
+        // we include the terminal '"' so we know where to end
+        // This is safe since we check sub's length in the range access above and only
+        // create sub sliced form sub to `sub.len()`.
+
+        let src = unsafe { data.get_unchecked(idx..) };
+        let mut src_i = 0;
+        let mut len = src_i;
+        loop {
+            let v = unsafe { v128_load(src.as_ptr().add(src_i).cast::<v128>()) };
+
+            let bs_bits = u8x16_bitmask(u8x16_eq(v, u8x16_splat(b'\\')));
+            let quote_bits = u8x16_bitmask(u8x16_eq(v, u8x16_splat(b'"')));
+            if (bs_bits.wrapping_sub(1) & quote_bits) != 0 {
+                // we encountered quotes first. Move dst to point to quotes and exit
+                // find out where the quote is...
+                let quote_dist = quote_bits.trailing_zeros();
+
+                ///////////////////////
+                // Above, check for overflow in case someone has a crazy string (>=4GB?)
+                // But only add the overflow check when the document itself exceeds 4GB
+                // Currently unneeded because we refuse to parse docs larger or equal to 4GB.
+                ////////////////////////
+
+                // we advance the point, accounting for the fact that we have a NULl termination
+
+                len += quote_dist as usize;
+                unsafe {
+                    let v = input.get_unchecked(idx..idx + len) as *const [u8] as *const str;
+                    return Ok(&*v);
+                }
+
+                // we compare the pointers since we care if they are 'at the same spot'
+                // not if they are the same value
+            }
+            if (quote_bits.wrapping_sub(1) & bs_bits) == 0 {
+                // they are the same. Since they can't co-occur, it means we encountered
+                // neither.
+                src_i += 16;
+                len += 16;
+            } else {
+                // Move to the 'bad' character
+                let bs_dist = bs_bits.trailing_zeros();
+                len += bs_dist as usize;
+                src_i += bs_dist as usize;
+                break;
+            }
+        }
+
+        let mut dst_i = 0;
+
+        // To be more conform with upstream
+        loop {
+            let v = unsafe { v128_load(src.as_ptr().add(src_i).cast::<v128>()) };
+
+            unsafe {
+                v128_store(buffer.as_mut_ptr().add(dst_i).cast::<v128>(), v);
+            };
+
+            // store to dest unconditionally - we can overwrite the bits we don't like
+            // later
+            let bs_bits = u8x16_bitmask(u8x16_eq(v, u8x16_splat(b'\\')));
+            let quote_bits = u8x16_bitmask(u8x16_eq(v, u8x16_splat(b'"')));
+            if (bs_bits.wrapping_sub(1) & quote_bits) != 0 {
+                // we encountered quotes first. Move dst to point to quotes and exit
+                // find out where the quote is...
+                let quote_dist = quote_bits.trailing_zeros();
+
+                ///////////////////////
+                // Above, check for overflow in case someone has a crazy string (>=4GB?)
+                // But only add the overflow check when the document itself exceeds 4GB
+                // Currently unneeded because we refuse to parse docs larger or equal to 4GB.
+                ////////////////////////
+
+                // we advance the point, accounting for the fact that we have a NULl termination
+
+                dst_i += quote_dist as usize;
+                unsafe {
+                    input
+                        .get_unchecked_mut(idx + len..idx + len + dst_i)
+                        .clone_from_slice(buffer.get_unchecked(..dst_i));
+                    let v =
+                        input.get_unchecked(idx..idx + len + dst_i) as *const [u8] as *const str;
+                    return Ok(&*v);
+                }
+
+                // we compare the pointers since we care if they are 'at the same spot'
+                // not if they are the same value
+            }
+            if (quote_bits.wrapping_sub(1) & bs_bits) != 0 {
+                // find out where the backspace is
+                let bs_dist = bs_bits.trailing_zeros();
+                let escape_char = unsafe { *src.get_unchecked(src_i + bs_dist as usize + 1) };
+                // we encountered backslash first. Handle backslash
+                if escape_char == b'u' {
+                    // move src/dst up to the start; they will be further adjusted
+                    // within the unicode codepoint handling code.
+                    src_i += bs_dist as usize;
+                    dst_i += bs_dist as usize;
+                    let (o, s) = if let Ok(r) =
+                        handle_unicode_codepoint(unsafe { src.get_unchecked(src_i..) }, unsafe {
+                            buffer.get_unchecked_mut(dst_i..)
+                        }) {
+                        r
+                    } else {
+                        return Err(Self::raw_error(src_i, 'u', InvalidUnicodeCodepoint));
+                    };
+                    if o == 0 {
+                        return Err(Self::raw_error(src_i, 'u', InvalidUnicodeCodepoint));
+                    };
+                    // We moved o steps forward at the destination and 6 on the source
+                    src_i += s;
+                    dst_i += o;
+                } else {
+                    // simple 1:1 conversion. Will eat bs_dist+2 characters in input and
+                    // write bs_dist+1 characters to output
+                    // note this may reach beyond the part of the buffer we've actually
+                    // seen. I think this is ok
+                    let escape_result = unsafe { *ESCAPE_MAP.get_unchecked(escape_char as usize) };
+                    if escape_result == 0 {
+                        return Err(Self::raw_error(src_i, escape_char as char, InvalidEscape));
+                    }
+                    unsafe {
+                        *buffer.get_unchecked_mut(dst_i + bs_dist as usize) = escape_result;
+                    }
+                    src_i += bs_dist as usize + 2;
+                    dst_i += bs_dist as usize + 1;
+                }
+            } else {
+                // they are the same. Since they can't co-occur, it means we encountered
+                // neither.
+                src_i += 16;
+                dst_i += 16;
+            }
+        }
+    }
+}

--- a/src/simd128/mod.rs
+++ b/src/simd128/mod.rs
@@ -1,0 +1,2 @@
+pub mod deser;
+pub mod stage1;

--- a/src/simd128/stage1.rs
+++ b/src/simd128/stage1.rs
@@ -1,0 +1,211 @@
+use std::arch::wasm32::*;
+use std::mem;
+
+use crate::Stage1Parse;
+
+pub const SIMDJSON_PADDING: usize = mem::size_of::<v128>() * 2;
+pub const SIMDINPUT_LENGTH: usize = 64;
+
+#[derive(Debug)]
+pub(crate) struct SimdInput {
+    v0: v128,
+    v1: v128,
+    v2: v128,
+    v3: v128,
+}
+
+impl SimdInput {
+    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[allow(clippy::cast_ptr_alignment)]
+    pub(crate) fn new(ptr: &[u8]) -> Self {
+        unsafe {
+            Self {
+                v0: v128_load(ptr.as_ptr().cast::<v128>()),
+                v1: v128_load(ptr.as_ptr().add(16).cast::<v128>()),
+                v2: v128_load(ptr.as_ptr().add(32).cast::<v128>()),
+                v3: v128_load(ptr.as_ptr().add(48).cast::<v128>()),
+            }
+        }
+    }
+}
+
+impl Stage1Parse<v128> for SimdInput {
+    #[cfg_attr(not(feature = "no-inline"), inline(always))]
+    fn compute_quote_mask(mut quote_bits: u64) -> u64 {
+        #[allow(clippy::cast_sign_loss)]
+        let b = -1_i64 as u64;
+        let mut prod = 0;
+
+        while quote_bits != 0 {
+            prod ^= b.wrapping_mul(quote_bits & 0_u64.wrapping_sub(quote_bits));
+            quote_bits &= quote_bits.wrapping_sub(1);
+        }
+
+        prod
+    }
+
+    /// a straightforward comparison of a mask against input
+    #[cfg_attr(not(feature = "no-inline"), inline(always))]
+    fn cmp_mask_against_input(&self, m: u8) -> u64 {
+        let mask = u8x16_splat(m);
+        let cmp_res_0 = u8x16_eq(self.v0, mask);
+        let res_0 = u8x16_bitmask(cmp_res_0) as u64;
+        let cmp_res_1 = u8x16_eq(self.v1, mask);
+        let res_1 = u8x16_bitmask(cmp_res_1) as u64;
+        let cmp_res_2 = u8x16_eq(self.v2, mask);
+        let res_2 = u8x16_bitmask(cmp_res_2) as u64;
+        let cmp_res_3 = u8x16_eq(self.v3, mask);
+        let res_3 = u8x16_bitmask(cmp_res_3) as u64;
+        res_0 | (res_1 << 16) | (res_2 << 32) | (res_3 << 48)
+    }
+
+    // find all values less than or equal than the content of maxval (using unsigned arithmetic)
+    #[cfg_attr(not(feature = "no-inline"), inline(always))]
+    fn unsigned_lteq_against_input(&self, maxval: v128) -> u64 {
+        let cmp_res_0 = u8x16_le(self.v0, maxval);
+        let res_0 = u8x16_bitmask(cmp_res_0) as u64;
+        let cmp_res_1 = u8x16_le(self.v1, maxval);
+        let res_1 = u8x16_bitmask(cmp_res_1) as u64;
+        let cmp_res_2 = u8x16_le(self.v2, maxval);
+        let res_2 = u8x16_bitmask(cmp_res_2) as u64;
+        let cmp_res_3 = u8x16_le(self.v3, maxval);
+        let res_3 = u8x16_bitmask(cmp_res_3) as u64;
+        res_0 | (res_1 << 16) | (res_2 << 32) | (res_3 << 48)
+    }
+
+    #[cfg_attr(not(feature = "no-inline"), inline(always))]
+    #[allow(clippy::cast_sign_loss)]
+    fn find_whitespace_and_structurals(&self, whitespace: &mut u64, structurals: &mut u64) {
+        // do a 'shufti' to detect structural JSON characters
+        // they are
+        // * `{` 0x7b
+        // * `}` 0x7d
+        // * `:` 0x3a
+        // * `[` 0x5b
+        // * `]` 0x5d
+        // * `,` 0x2c
+        // these go into the first 3 buckets of the comparison (1/2/4)
+
+        // we are also interested in the four whitespace characters:
+        // * space 0x20
+        // * linefeed 0x0a
+        // * horizontal tab 0x09
+        // * carriage return 0x0d
+        // these go into the next 2 buckets of the comparison (8/16)
+        const LOW_NIBBLE_MASK: v128 = u8x16(16, 0, 0, 0, 0, 0, 0, 0, 0, 8, 12, 1, 2, 9, 0, 0);
+        const HIGH_NIBBLE_MASK: v128 = u8x16(8, 0, 18, 4, 0, 1, 0, 1, 0, 0, 0, 3, 2, 1, 0, 0);
+
+        let structural_shufti_mask = u8x16_splat(0x7);
+        let whitespace_shufti_mask = u8x16_splat(0x18);
+        let low_nib_and_mask = u8x16_splat(0xf);
+        let high_nib_and_mask = u8x16_splat(0x7f);
+        let zero_mask = u8x16_splat(0);
+
+        let v_v0 = v128_and(
+            u8x16_swizzle(LOW_NIBBLE_MASK, v128_and(self.v0, low_nib_and_mask)),
+            u8x16_swizzle(
+                HIGH_NIBBLE_MASK,
+                v128_and(u8x16_shr(self.v0, 4), high_nib_and_mask),
+            ),
+        );
+        let v_v1 = v128_and(
+            u8x16_swizzle(LOW_NIBBLE_MASK, v128_and(self.v1, low_nib_and_mask)),
+            u8x16_swizzle(
+                HIGH_NIBBLE_MASK,
+                v128_and(u8x16_shr(self.v1, 4), high_nib_and_mask),
+            ),
+        );
+        let v_v2 = v128_and(
+            u8x16_swizzle(LOW_NIBBLE_MASK, v128_and(self.v2, low_nib_and_mask)),
+            u8x16_swizzle(
+                HIGH_NIBBLE_MASK,
+                v128_and(u8x16_shr(self.v2, 4), high_nib_and_mask),
+            ),
+        );
+        let v_v3 = v128_and(
+            u8x16_swizzle(LOW_NIBBLE_MASK, v128_and(self.v3, low_nib_and_mask)),
+            u8x16_swizzle(
+                HIGH_NIBBLE_MASK,
+                v128_and(u8x16_shr(self.v3, 4), high_nib_and_mask),
+            ),
+        );
+        let tmp_v0 = u8x16_eq(v128_and(v_v0, structural_shufti_mask), zero_mask);
+        let tmp_v1 = u8x16_eq(v128_and(v_v1, structural_shufti_mask), zero_mask);
+        let tmp_v2 = u8x16_eq(v128_and(v_v2, structural_shufti_mask), zero_mask);
+        let tmp_v3 = u8x16_eq(v128_and(v_v3, structural_shufti_mask), zero_mask);
+
+        let structural_res_0 = u8x16_bitmask(tmp_v0) as u64;
+        let structural_res_1 = u8x16_bitmask(tmp_v1) as u64;
+        let structural_res_2 = u8x16_bitmask(tmp_v2) as u64;
+        let structural_res_3 = u8x16_bitmask(tmp_v3) as u64;
+
+        *structurals = !(structural_res_0
+            | (structural_res_1 << 16)
+            | (structural_res_2 << 32)
+            | (structural_res_3 << 48));
+
+        let tmp_ws_v0 = u8x16_eq(v128_and(v_v0, whitespace_shufti_mask), zero_mask);
+        let tmp_ws_v1 = u8x16_eq(v128_and(v_v1, whitespace_shufti_mask), zero_mask);
+        let tmp_ws_v2 = u8x16_eq(v128_and(v_v2, whitespace_shufti_mask), zero_mask);
+        let tmp_ws_v3 = u8x16_eq(v128_and(v_v3, whitespace_shufti_mask), zero_mask);
+
+        let ws_res_0 = u8x16_bitmask(tmp_ws_v0) as u64;
+        let ws_res_1 = u8x16_bitmask(tmp_ws_v1) as u64;
+        let ws_res_2 = u8x16_bitmask(tmp_ws_v2) as u64;
+        let ws_res_3 = u8x16_bitmask(tmp_ws_v3) as u64;
+
+        *whitespace = !(ws_res_0 | (ws_res_1 << 16) | (ws_res_2 << 32) | (ws_res_3 << 48));
+    }
+
+    // flatten out values in 'bits' assuming that they are are to have values of idx
+    // plus their position in the bitvector, and store these indexes at
+    // base_ptr[base] incrementing base as we go
+    // will potentially store extra values beyond end of valid bits, so base_ptr
+    // needs to be large enough to handle this
+    //TODO: usize was u32 here does this matter?
+    #[cfg_attr(not(feature = "no-inline"), inline(always))]
+    fn flatten_bits(base: &mut Vec<u32>, idx: u32, mut bits: u64) {
+        let cnt: usize = bits.count_ones() as usize;
+        let mut l = base.len();
+        let idx_minus_64 = idx.wrapping_sub(64);
+        let idx_64_v = u32x4_splat(idx_minus_64);
+
+        // We're doing some trickery here.
+        // We reserve 64 extra entries, because we've at most 64 bit to set
+        // then we trunctate the base to the next base (that we calcuate above)
+        // We later indiscriminatory writre over the len we set but that's OK
+        // since we ensure we reserve the needed space
+        base.reserve(64);
+        unsafe {
+            base.set_len(l + cnt);
+        }
+
+        while bits != 0 {
+            let v0 = bits.trailing_zeros() as u32;
+            bits &= bits.wrapping_sub(1);
+            let v1 = bits.trailing_zeros() as u32;
+            bits &= bits.wrapping_sub(1);
+            let v2 = bits.trailing_zeros() as u32;
+            bits &= bits.wrapping_sub(1);
+            let v3 = bits.trailing_zeros() as u32;
+            bits &= bits.wrapping_sub(1);
+
+            let v = u32x4(v0, v1, v2, v3);
+            let v = u32x4_add(idx_64_v, v);
+            unsafe {
+                v128_store(base.as_mut_ptr().add(l).cast::<v128>(), v);
+            }
+            l += 4;
+        }
+    }
+
+    #[cfg_attr(not(feature = "no-inline"), inline(always))]
+    fn fill_s8(n: i8) -> v128 {
+        i8x16_splat(n)
+    }
+
+    #[cfg_attr(not(feature = "no-inline"), inline(always))]
+    fn zero() -> v128 {
+        i8x16_splat(0)
+    }
+}

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -843,8 +843,10 @@ mod test {
         assert_eq!(Value::default(), Value::null());
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     use proptest::prelude::*;
 
+    #[cfg(not(target_arch = "wasm32"))]
     fn arb_value() -> BoxedStrategy<Value<'static>> {
         let leaf = prop_oneof![
             Just(Value::Static(StaticNode::Null)),
@@ -878,6 +880,7 @@ mod test {
         .boxed()
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     proptest! {
         #![proptest_config(ProptestConfig {
             .. ProptestConfig::default()

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -780,7 +780,9 @@ mod test {
         assert_eq!(Value::default(), Value::null());
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     use proptest::prelude::*;
+    #[cfg(not(target_arch = "wasm32"))]
     fn arb_value() -> BoxedStrategy<Value> {
         let leaf = prop_oneof![
             Just(Value::Static(StaticNode::Null)),
@@ -811,6 +813,7 @@ mod test {
         .boxed()
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     proptest! {
         #![proptest_config(ProptestConfig {
             .. ProptestConfig::default()

--- a/tests/jsonchecker.rs
+++ b/tests/jsonchecker.rs
@@ -1,5 +1,4 @@
-use std::fs::File;
-use std::io::Read;
+use std::{fs::File, io::Read};
 
 macro_rules! pass {
     ($file:ident) => {


### PR DESCRIPTION
This adds support for two targets: 
1) `wasm32-unknown-unknown` - the current go to for running Rust on web browsers. The standard library is incredibly limited here and running tests is difficult.
2) `wasm32-wasi` - currently most useful for running tests, but may become more desirable in the future due to powerful sandboxing features offered by wasm runtimes on server.

In theory, any future wasm32 targets will be supported without any modification - e.g. `wasm32-web`. I've not made any effort to support `wasm64` yet, though enabling this in the future should be a simple matter of changing some cfg macros.

Some key changes and issues:
- proptest is incompatible with wasm targets as it relies on being able to fork, which is not possible. As a result, this dev dependency has to be gated and tests using it turned off on wasm targets. Due to `unused_imports` being a denied lint, certain imports in tests had to be broken up to allow compilation of tests on wasm32.
- testing requires wasmtime; a make rule has been added to make this as easy as possible. This could be substituted for any other wasm/wasi runtime.
- simdutf8 is currently a git dependency; support for wasm has not yet been included in a release of this crate
- value-trait also needed modification to support this, and I will open a separate PR there. Due to breaking changes this PR will target value-trait's 0.2.1 tag, not the current head.
- benchmarking doesn't work as libc ends up in the dependency graph somehow - I've not looked into this yet.
- whilst comparing the implementation for wasm to the neon version I noticed that the `vtstq_u8` intrinsic is now part of the standard library and so removed the temporary implementation. Do let me know if you'd like this reverted.
- wasm currently lacks any kind of runtime feature detection (though this should be possible in the future through [exception handling](https://github.com/WebAssembly/exception-handling/blob/master/proposals/exception-handling/Exceptions.md)), and simd instructions may be disabled (though in most cases they seem to be enabled by default). This may cause issues when considering the `allow-non-simd` feature.

closes #217