### PR TITLE
Add bounds checked get_unchecked, use it everywhere.

### DIFF
--- a/src/avx2/deser.rs
+++ b/src/avx2/deser.rs
@@ -12,6 +12,7 @@ use std::arch::x86_64::{
 use std::mem;
 
 pub use crate::error::{Error, ErrorType};
+use crate::safer_unchecked::GetSaferUnchecked;
 use crate::stringparse::{handle_unicode_codepoint, ESCAPE_MAP};
 use crate::Deserializer;
 pub use crate::Result;
@@ -44,7 +45,7 @@ impl<'de> Deserializer<'de> {
         // This is safe since we check sub's length in the range access above and only
         // create sub sliced form sub to `sub.len()`.
 
-        let src: &[u8] = unsafe { data.get_unchecked(idx..) };
+        let src: &[u8] = unsafe { data.get_kinda_unchecked(idx..) };
         let mut src_i: usize = 0;
         let mut len = src_i;
         loop {
@@ -77,7 +78,7 @@ impl<'de> Deserializer<'de> {
 
                 len += quote_dist as usize;
                 unsafe {
-                    let v = input.get_unchecked(idx..idx + len) as *const [u8] as *const str;
+                    let v = input.get_kinda_unchecked(idx..idx + len) as *const [u8] as *const str;
                     return Ok(&*v);
                 }
 
@@ -142,10 +143,10 @@ impl<'de> Deserializer<'de> {
                 dst_i += quote_dist as usize;
                 unsafe {
                     input
-                        .get_unchecked_mut(idx + len..idx + len + dst_i)
-                        .clone_from_slice(buffer.get_unchecked(..dst_i));
+                        .get_kinda_unchecked_mut(idx + len..idx + len + dst_i)
+                        .clone_from_slice(buffer.get_kinda_unchecked(..dst_i));
                     let v =
-                        input.get_unchecked(idx..idx + len + dst_i) as *const [u8] as *const str;
+                        input.get_kinda_unchecked(idx..idx + len + dst_i) as *const [u8] as *const str;
                     return Ok(&*v);
                 }
 
@@ -155,7 +156,7 @@ impl<'de> Deserializer<'de> {
             if (quote_bits.wrapping_sub(1) & bs_bits) != 0 {
                 // find out where the backspace is
                 let bs_dist: u32 = bs_bits.trailing_zeros();
-                let escape_char: u8 = unsafe { *src.get_unchecked(src_i + bs_dist as usize + 1) };
+                let escape_char: u8 = unsafe { *src.get_kinda_unchecked(src_i + bs_dist as usize + 1) };
                 // we encountered backslash first. Handle backslash
                 if escape_char == b'u' {
                     // move src/dst up to the start; they will be further adjusted
@@ -163,8 +164,8 @@ impl<'de> Deserializer<'de> {
                     src_i += bs_dist as usize;
                     dst_i += bs_dist as usize;
                     let (o, s) = if let Ok(r) =
-                        handle_unicode_codepoint(unsafe { src.get_unchecked(src_i..) }, unsafe {
-                            buffer.get_unchecked_mut(dst_i..)
+                        handle_unicode_codepoint(unsafe { src.get_kinda_unchecked(src_i..) }, unsafe {
+                            buffer.get_kinda_unchecked_mut(dst_i..)
                         }) {
                         r
                     } else {
@@ -182,12 +183,12 @@ impl<'de> Deserializer<'de> {
                     // note this may reach beyond the part of the buffer we've actually
                     // seen. I think this is ok
                     let escape_result: u8 =
-                        unsafe { *ESCAPE_MAP.get_unchecked(escape_char as usize) };
+                        unsafe { *ESCAPE_MAP.get_kinda_unchecked(escape_char as usize) };
                     if escape_result == 0 {
                         return Err(Self::raw_error(src_i, escape_char as char, InvalidEscape));
                     }
                     unsafe {
-                        *buffer.get_unchecked_mut(dst_i + bs_dist as usize) = escape_result;
+                        *buffer.get_kinda_unchecked_mut(dst_i + bs_dist as usize) = escape_result;
                     }
                     src_i += bs_dist as usize + 2;
                     dst_i += bs_dist as usize + 1;

--- a/src/charutils.rs
+++ b/src/charutils.rs
@@ -1,3 +1,5 @@
+use crate::safer_unchecked::GetSaferUnchecked;
+
 const STRUCTURAL_OR_WHITESPACE_NEGATED: [u32; 256] = [
     0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
     0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1,
@@ -22,12 +24,12 @@ const STRUCTURAL_OR_WHITESPACE: [u32; 256] = [
 
 #[cfg_attr(not(feature = "no-inline"), inline(always))]
 pub fn is_not_structural_or_whitespace(c: u8) -> u32 {
-    unsafe { *STRUCTURAL_OR_WHITESPACE_NEGATED.get_unchecked(c as usize) }
+    unsafe { *STRUCTURAL_OR_WHITESPACE_NEGATED.get_kinda_unchecked(c as usize) }
 }
 
 #[cfg_attr(not(feature = "no-inline"), inline(always))]
 pub fn is_structural_or_whitespace(c: u8) -> u32 {
-    unsafe { *STRUCTURAL_OR_WHITESPACE.get_unchecked(c as usize) }
+    unsafe { *STRUCTURAL_OR_WHITESPACE.get_kinda_unchecked(c as usize) }
 }
 
 const DIGITTOVAL: [i8; 256] = [
@@ -55,10 +57,10 @@ pub fn hex_to_u32_nocheck(src: &[u8]) -> u32 {
     // invalid value. After the shifts, this will *still* result in the outcome that the high 16 bits of any
     // value with any invalid char will be all 1's. We check for this in the caller.
     unsafe {
-        let v1: i32 = i32::from(*DIGITTOVAL.get_unchecked(*src.get_unchecked(0) as usize));
-        let v2: i32 = i32::from(*DIGITTOVAL.get_unchecked(*src.get_unchecked(1) as usize));
-        let v3: i32 = i32::from(*DIGITTOVAL.get_unchecked(*src.get_unchecked(2) as usize));
-        let v4: i32 = i32::from(*DIGITTOVAL.get_unchecked(*src.get_unchecked(3) as usize));
+        let v1: i32 = i32::from(*DIGITTOVAL.get_kinda_unchecked(*src.get_kinda_unchecked(0) as usize));
+        let v2: i32 = i32::from(*DIGITTOVAL.get_kinda_unchecked(*src.get_kinda_unchecked(1) as usize));
+        let v3: i32 = i32::from(*DIGITTOVAL.get_kinda_unchecked(*src.get_kinda_unchecked(2) as usize));
+        let v4: i32 = i32::from(*DIGITTOVAL.get_kinda_unchecked(*src.get_kinda_unchecked(3) as usize));
         (v1 << 12 | v2 << 8 | v3 << 4 | v4) as u32
     }
 }
@@ -80,27 +82,27 @@ pub fn hex_to_u32_nocheck(src: &[u8]) -> u32 {
 pub fn codepoint_to_utf8(cp: u32, c: &mut [u8]) -> usize {
     unsafe {
         if cp <= 0x7F {
-            *c.get_unchecked_mut(0) = cp as u8;
+            *c.get_kinda_unchecked_mut(0) = cp as u8;
             return 1; // ascii
         }
         if cp <= 0x7FF {
-            *c.get_unchecked_mut(0) = ((cp >> 6) + 192) as u8;
-            *c.get_unchecked_mut(1) = ((cp & 63) + 128) as u8;
+            *c.get_kinda_unchecked_mut(0) = ((cp >> 6) + 192) as u8;
+            *c.get_kinda_unchecked_mut(1) = ((cp & 63) + 128) as u8;
             return 2; // universal plane
                       //  Surrogates are treated elsewhere...
                       //} //else if (0xd800 <= cp && cp <= 0xdfff) {
                       //  return 0; // surrogates // could put assert here
         } else if cp <= 0xFFFF {
-            *c.get_unchecked_mut(0) = ((cp >> 12) + 224) as u8;
-            *c.get_unchecked_mut(1) = (((cp >> 6) & 63) + 128) as u8;
-            *c.get_unchecked_mut(2) = ((cp & 63) + 128) as u8;
+            *c.get_kinda_unchecked_mut(0) = ((cp >> 12) + 224) as u8;
+            *c.get_kinda_unchecked_mut(1) = (((cp >> 6) & 63) + 128) as u8;
+            *c.get_kinda_unchecked_mut(2) = ((cp & 63) + 128) as u8;
             return 3;
         } else if cp <= 0x0010_FFFF {
             // if you know you have a valid code point, this is not needed
-            *c.get_unchecked_mut(0) = ((cp >> 18) + 240) as u8;
-            *c.get_unchecked_mut(1) = (((cp >> 12) & 63) + 128) as u8;
-            *c.get_unchecked_mut(2) = (((cp >> 6) & 63) + 128) as u8;
-            *c.get_unchecked_mut(3) = ((cp & 63) + 128) as u8;
+            *c.get_kinda_unchecked_mut(0) = ((cp >> 18) + 240) as u8;
+            *c.get_kinda_unchecked_mut(1) = (((cp >> 12) & 63) + 128) as u8;
+            *c.get_kinda_unchecked_mut(2) = (((cp >> 6) & 63) + 128) as u8;
+            *c.get_kinda_unchecked_mut(3) = ((cp & 63) + 128) as u8;
             return 4;
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![deny(warnings)]
 #![cfg_attr(feature = "hints", feature(core_intrinsics))]
-#![deny(warnings)]
 #![warn(unused_extern_crates)]
 #![deny(
     clippy::all,
@@ -488,13 +487,14 @@ impl<'de> Deserializer<'de> {
                 len,
             );
 
-            input_buffer.as_mut_ptr().add(len).write(0);
+            let to_fill = input_buffer.capacity() - len;
+            std::ptr::write_bytes(input_buffer.as_mut_ptr().add(len), 0, to_fill);
 
-            input_buffer.set_len(len);
+            input_buffer.set_len(input_buffer.capacity());
         };
 
         let s1_result: std::result::Result<Vec<u32>, ErrorType> =
-            unsafe { Self::find_structural_bits(input_buffer) };
+            unsafe { Self::find_structural_bits(input) };
 
         let structural_indexes = match s1_result {
             Ok(i) => i,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,9 @@ mod macros;
 mod error;
 mod numberparse;
 mod stringparse;
+mod safer_unchecked;
+
+use safer_unchecked::GetSaferUnchecked;
 
 /// Reexport of Cow
 pub mod cow;
@@ -481,9 +484,9 @@ impl<'de> Deserializer<'de> {
         unsafe {
             input_buffer
                 .as_mut_slice()
-                .get_unchecked_mut(..len)
+                .get_kinda_unchecked_mut(..len)
                 .clone_from_slice(input);
-            *(input_buffer.get_unchecked_mut(len)) = 0;
+            *(input_buffer.get_kinda_unchecked_mut(len)) = 0;
             input_buffer.set_len(len);
         };
 
@@ -519,7 +522,7 @@ impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     pub unsafe fn next_(&mut self) -> Node<'de> {
         self.idx += 1;
-        *self.tape.get_unchecked(self.idx)
+        *self.tape.get_kinda_unchecked(self.idx)
     }
 
     //#[inline(never)]
@@ -569,7 +572,7 @@ impl<'de> Deserializer<'de> {
               __builtin_prefetch(buf + idx + 128);
             #endif
              */
-            let chunk = input.get_unchecked(idx..idx + 64);
+            let chunk = input.get_kinda_unchecked(idx..idx + 64);
             utf8_validator.update_from_chunks(chunk);
 
             let input = SimdInput::new(chunk);

--- a/src/neon/deser.rs
+++ b/src/neon/deser.rs
@@ -1,3 +1,4 @@
+use crate::safer_unchecked::GetSaferUnchecked;
 use crate::error::ErrorType;
 use crate::neon::stage1::bit_mask;
 use crate::stringparse::{handle_unicode_codepoint, ESCAPE_MAP};
@@ -64,14 +65,14 @@ impl<'de> Deserializer<'de> {
         // This is safe since we check sub's length in the range access above and only
         // create sub sliced form sub to `sub.len()`.
 
-        let src: &[u8] = unsafe { data.get_unchecked(idx..) };
+        let src: &[u8] = unsafe { data.get_kinda_unchecked(idx..) };
         let mut src_i: usize = 0;
         let mut len = src_i;
         loop {
             let (v0, v1) = unsafe {
                 (
-                    vld1q_u8(src.get_unchecked(src_i..src_i + 16).as_ptr()),
-                    vld1q_u8(src.get_unchecked(src_i + 16..src_i + 32).as_ptr()),
+                    vld1q_u8(src.get_kinda_unchecked(src_i..src_i + 16).as_ptr()),
+                    vld1q_u8(src.get_kinda_unchecked(src_i + 16..src_i + 32).as_ptr()),
                 )
             };
 
@@ -92,7 +93,7 @@ impl<'de> Deserializer<'de> {
 
                 len += quote_dist as usize;
                 unsafe {
-                    let v = input.get_unchecked(idx..idx + len) as *const [u8] as *const str;
+                    let v = input.get_kinda_unchecked(idx..idx + len) as *const [u8] as *const str;
                     return Ok(&*v);
                 }
 
@@ -119,15 +120,15 @@ impl<'de> Deserializer<'de> {
         loop {
             let (v0, v1) = unsafe {
                 (
-                    vld1q_u8(src.get_unchecked(src_i..src_i + 16).as_ptr()),
-                    vld1q_u8(src.get_unchecked(src_i + 16..src_i + 32).as_ptr()),
+                    vld1q_u8(src.get_kinda_unchecked(src_i..src_i + 16).as_ptr()),
+                    vld1q_u8(src.get_kinda_unchecked(src_i + 16..src_i + 32).as_ptr()),
                 )
             };
 
             unsafe {
                 buffer
-                    .get_unchecked_mut(dst_i..dst_i + 32)
-                    .copy_from_slice(src.get_unchecked(src_i..src_i + 32));
+                    .get_kinda_unchecked_mut(dst_i..dst_i + 32)
+                    .copy_from_slice(src.get_kinda_unchecked(src_i..src_i + 32));
             }
 
             // store to dest unconditionally - we can overwrite the bits we don't like
@@ -150,10 +151,10 @@ impl<'de> Deserializer<'de> {
                 dst_i += quote_dist as usize;
                 unsafe {
                     input
-                        .get_unchecked_mut(idx + len..idx + len + dst_i)
-                        .clone_from_slice(buffer.get_unchecked(..dst_i));
+                        .get_kinda_unchecked_mut(idx + len..idx + len + dst_i)
+                        .clone_from_slice(buffer.get_kinda_unchecked(..dst_i));
                     let v =
-                        input.get_unchecked(idx..idx + len + dst_i) as *const [u8] as *const str;
+                        input.get_kinda_unchecked(idx..idx + len + dst_i) as *const [u8] as *const str;
                     return Ok(&*v);
                 }
 
@@ -163,7 +164,7 @@ impl<'de> Deserializer<'de> {
             if (quote_bits.wrapping_sub(1) & bs_bits) != 0 {
                 // find out where the backspace is
                 let bs_dist: u32 = bs_bits.trailing_zeros();
-                let escape_char: u8 = unsafe { *src.get_unchecked(src_i + bs_dist as usize + 1) };
+                let escape_char: u8 = unsafe { *src.get_kinda_unchecked(src_i + bs_dist as usize + 1) };
                 // we encountered backslash first. Handle backslash
                 if escape_char == b'u' {
                     // move src/dst up to the start; they will be further adjusted
@@ -171,8 +172,8 @@ impl<'de> Deserializer<'de> {
                     src_i += bs_dist as usize;
                     dst_i += bs_dist as usize;
                     let (o, s) = if let Ok(r) =
-                        handle_unicode_codepoint(unsafe { src.get_unchecked(src_i..) }, unsafe {
-                            buffer.get_unchecked_mut(dst_i..)
+                        handle_unicode_codepoint(unsafe { src.get_kinda_unchecked(src_i..) }, unsafe {
+                            buffer.get_kinda_unchecked_mut(dst_i..)
                         }) {
                         r
                     } else {
@@ -190,12 +191,12 @@ impl<'de> Deserializer<'de> {
                     // note this may reach beyond the part of the buffer we've actually
                     // seen. I think this is ok
                     let escape_result: u8 =
-                        unsafe { *ESCAPE_MAP.get_unchecked(escape_char as usize) };
+                        unsafe { *ESCAPE_MAP.get_kinda_unchecked(escape_char as usize) };
                     if escape_result == 0 {
                         return Err(Self::raw_error(src_i, escape_char as char, InvalidEscape));
                     }
                     unsafe {
-                        *buffer.get_unchecked_mut(dst_i + bs_dist as usize) = escape_result;
+                        *buffer.get_kinda_unchecked_mut(dst_i + bs_dist as usize) = escape_result;
                     }
                     src_i += bs_dist as usize + 2;
                     dst_i += bs_dist as usize + 1;

--- a/src/safer_unchecked.rs
+++ b/src/safer_unchecked.rs
@@ -1,0 +1,37 @@
+use core::slice::SliceIndex;
+
+pub trait GetSaferUnchecked<T> {
+    unsafe fn get_kinda_unchecked<I>(&self, index: I) -> &<I as SliceIndex<[T]>>::Output
+    where
+        I: SliceIndex<[T]>;
+
+    unsafe fn get_kinda_unchecked_mut<I>(&mut self, index: I) -> &mut <I as SliceIndex<[T]>>::Output
+    where
+        I: SliceIndex<[T]>;
+}
+
+impl<T> GetSaferUnchecked<T> for [T] {
+    #[inline(always)]
+    unsafe fn get_kinda_unchecked<I>(&self, index: I) -> &<I as SliceIndex<[T]>>::Output
+    where
+        I: SliceIndex<[T]>,
+    {
+        if cfg!(debug_assertions) {
+            &self[index]
+        } else {
+            self.get_unchecked(index)
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn get_kinda_unchecked_mut<I>(&mut self, index: I) -> &mut <I as SliceIndex<[T]>>::Output
+    where
+        I: SliceIndex<[T]>,
+    {
+        if cfg!(debug_assertions) {
+            &mut self[index]
+        } else {
+            self.get_unchecked_mut(index)
+        }
+    }
+}

--- a/src/sse42/deser.rs
+++ b/src/sse42/deser.rs
@@ -11,6 +11,7 @@ use std::mem;
 
 pub use crate::error::{Error, ErrorType};
 use crate::stringparse::{handle_unicode_codepoint, ESCAPE_MAP};
+use crate::safer_unchecked::GetSaferUnchecked;
 use crate::Deserializer;
 pub use crate::Result;
 
@@ -39,7 +40,7 @@ impl<'de> Deserializer<'de> {
         // This is safe since we check sub's length in the range access above and only
         // create sub sliced form sub to `sub.len()`.
 
-        let src: &[u8] = unsafe { data.get_unchecked(idx..) };
+        let src: &[u8] = unsafe { data.get_kinda_unchecked(idx..) };
         let mut src_i: usize = 0;
         let mut len = src_i;
         loop {
@@ -72,7 +73,7 @@ impl<'de> Deserializer<'de> {
 
                 len += quote_dist as usize;
                 unsafe {
-                    let v = input.get_unchecked(idx..idx + len) as *const [u8] as *const str;
+                    let v = input.get_kinda_unchecked(idx..idx + len) as *const [u8] as *const str;
                     return Ok(&*v);
                 }
 
@@ -137,10 +138,10 @@ impl<'de> Deserializer<'de> {
                 dst_i += quote_dist as usize;
                 unsafe {
                     input
-                        .get_unchecked_mut(idx + len..idx + len + dst_i)
-                        .clone_from_slice(buffer.get_unchecked(..dst_i));
+                        .get_kinda_unchecked_mut(idx + len..idx + len + dst_i)
+                        .clone_from_slice(buffer.get_kinda_unchecked(..dst_i));
                     let v =
-                        input.get_unchecked(idx..idx + len + dst_i) as *const [u8] as *const str;
+                        input.get_kinda_unchecked(idx..idx + len + dst_i) as *const [u8] as *const str;
                     return Ok(&*v);
                 }
 
@@ -150,7 +151,7 @@ impl<'de> Deserializer<'de> {
             if (quote_bits.wrapping_sub(1) & bs_bits) != 0 {
                 // find out where the backspace is
                 let bs_dist: u32 = bs_bits.trailing_zeros();
-                let escape_char: u8 = unsafe { *src.get_unchecked(src_i + bs_dist as usize + 1) };
+                let escape_char: u8 = unsafe { *src.get_kinda_unchecked(src_i + bs_dist as usize + 1) };
                 // we encountered backslash first. Handle backslash
                 if escape_char == b'u' {
                     // move src/dst up to the start; they will be further adjusted
@@ -158,8 +159,8 @@ impl<'de> Deserializer<'de> {
                     src_i += bs_dist as usize;
                     dst_i += bs_dist as usize;
                     let (o, s) = if let Ok(r) =
-                        handle_unicode_codepoint(unsafe { src.get_unchecked(src_i..) }, unsafe {
-                            buffer.get_unchecked_mut(dst_i..)
+                        handle_unicode_codepoint(unsafe { src.get_kinda_unchecked(src_i..) }, unsafe {
+                            buffer.get_kinda_unchecked_mut(dst_i..)
                         }) {
                         r
                     } else {
@@ -177,12 +178,12 @@ impl<'de> Deserializer<'de> {
                     // note this may reach beyond the part of the buffer we've actually
                     // seen. I think this is ok
                     let escape_result: u8 =
-                        unsafe { *ESCAPE_MAP.get_unchecked(escape_char as usize) };
+                        unsafe { *ESCAPE_MAP.get_kinda_unchecked(escape_char as usize) };
                     if escape_result == 0 {
                         return Err(Self::raw_error(src_i, escape_char as char, InvalidEscape));
                     }
                     unsafe {
-                        *buffer.get_unchecked_mut(dst_i + bs_dist as usize) = escape_result;
+                        *buffer.get_kinda_unchecked_mut(dst_i + bs_dist as usize) = escape_result;
                     }
                     src_i += bs_dist as usize + 2;
                     dst_i += bs_dist as usize + 1;

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -2,6 +2,7 @@
 use crate::charutils::is_not_structural_or_whitespace;
 use crate::value::tape::Node;
 use crate::{Deserializer, Error, ErrorType, Result};
+use crate::safer_unchecked::GetSaferUnchecked;
 use value_trait::StaticNode;
 
 #[cfg_attr(not(feature = "no-inline"), inline(always))]
@@ -20,7 +21,7 @@ pub fn is_valid_true_atom(loc: &[u8]) -> bool {
         let locval: u64 = *(loc.as_ptr().cast::<u64>());
 
         error = (locval & MASK4) ^ TV;
-        error |= u64::from(is_not_structural_or_whitespace(*loc.get_unchecked(4)));
+        error |= u64::from(is_not_structural_or_whitespace(*loc.get_kinda_unchecked(4)));
     }
     error == 0
 }
@@ -35,7 +36,7 @@ macro_rules! get {
 #[cfg(not(feature = "safe"))]
 macro_rules! get {
     ($a:expr, $i:expr) => {{
-        unsafe { $a.get_unchecked($i) }
+        unsafe { $a.get_kinda_unchecked($i) }
     }};
 }
 

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -8,6 +8,8 @@ use value_trait::StaticNode;
 #[cfg_attr(not(feature = "no-inline"), inline(always))]
 #[allow(clippy::cast_ptr_alignment)]
 pub fn is_valid_true_atom(loc: &[u8]) -> bool {
+    debug_assert!(loc.len() >= 8, "input too short to safely read a u64 from");
+
     // TODO is this expensive?
     let mut error: u64;
     unsafe {

--- a/src/stringparse.rs
+++ b/src/stringparse.rs
@@ -1,5 +1,6 @@
 use std::ops::Range;
 
+use crate::safer_unchecked::GetSaferUnchecked;
 use crate::charutils::{codepoint_to_utf8, hex_to_u32_nocheck};
 use crate::error::ErrorType;
 
@@ -38,19 +39,19 @@ pub(crate) fn handle_unicode_codepoint(
     // hex_to_u32_nocheck fills high 16 bits of the return value with 1s if the
     // conversion isn't valid; we defer the check for this to inside the
     // multilingual plane check
-    let mut code_point: u32 = hex_to_u32_nocheck(unsafe { src_ptr.get_unchecked(2..) });
-    src_ptr = unsafe { src_ptr.get_unchecked(6..) };
+    let mut code_point: u32 = hex_to_u32_nocheck(unsafe { src_ptr.get_kinda_unchecked(2..) });
+    src_ptr = unsafe { src_ptr.get_kinda_unchecked(6..) };
     let mut src_offset = 6;
     // check for low surrogate for characters outside the Basic
     // Multilingual Plane.
     if HIGH_SURROGATES.contains(&code_point) {
-        if (unsafe { *src_ptr.get_unchecked(0) } != b'\\')
-            || unsafe { *src_ptr.get_unchecked(1) } != b'u'
+        if (unsafe { *src_ptr.get_kinda_unchecked(0) } != b'\\')
+            || unsafe { *src_ptr.get_kinda_unchecked(1) } != b'u'
         {
             return Ok((0, src_offset));
         }
 
-        let code_point_2: u32 = hex_to_u32_nocheck(unsafe { src_ptr.get_unchecked(2..) });
+        let code_point_2: u32 = hex_to_u32_nocheck(unsafe { src_ptr.get_kinda_unchecked(2..) });
 
         // if the first code point is invalid we will get here, as we will go past
         // the check for being outside the Basic Multilingual plane. If we don't

--- a/src/value.rs
+++ b/src/value.rs
@@ -65,6 +65,7 @@ pub use self::owned::{
     Value as OwnedValue,
 };
 use crate::{Deserializer, Result};
+use crate::safer_unchecked::GetSaferUnchecked;
 use halfbrown::HashMap;
 use std::hash::Hash;
 use std::marker::PhantomData;
@@ -131,7 +132,7 @@ where
         unsafe {
             res.set_len(len);
             for i in 0..len {
-                std::ptr::write(res.get_unchecked_mut(i), self.parse());
+                std::ptr::write(res.get_kinda_unchecked_mut(i), self.parse());
             }
         }
         Value::from(res)

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -27,6 +27,7 @@ mod serialize;
 use crate::cow::Cow;
 use crate::prelude::*;
 use crate::{AlignedBuf, Deserializer, Node, Result, StaticNode};
+use crate::safer_unchecked::GetSaferUnchecked;
 use halfbrown::HashMap;
 use std::fmt;
 use std::ops::{Index, IndexMut};
@@ -385,7 +386,7 @@ impl<'de> BorrowDeserializer<'de> {
         unsafe {
             res.set_len(len);
             for i in 0..len {
-                std::ptr::write(res.get_unchecked_mut(i), self.parse());
+                std::ptr::write(res.get_kinda_unchecked_mut(i), self.parse());
             }
         }
         Value::Array(res)

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -25,6 +25,7 @@ mod serialize;
 
 use crate::prelude::*;
 use crate::{AlignedBuf, Deserializer, Node, Result, StaticNode};
+use crate::safer_unchecked::GetSaferUnchecked;
 use halfbrown::HashMap;
 use std::fmt;
 use std::ops::{Index, IndexMut};
@@ -323,7 +324,7 @@ impl<'de> OwnedDeserializer<'de> {
         unsafe {
             res.set_len(len);
             for i in 0..len {
-                std::ptr::write(res.get_unchecked_mut(i), self.parse());
+                std::ptr::write(res.get_kinda_unchecked_mut(i), self.parse());
             }
         }
         Value::Array(res)


### PR DESCRIPTION
This is HEAVY wip because these bounds check panic in ~~*every single test*~~ 95 tests. Indexing out of bounds is UB, which means this crate has no test that isn't currently UB :)

There's standard library checks for this too (if you run with `-Zbuild-std`), but those will just SIGILL your program, and you have to use gdb to get a backtrace.

So I copied this from where I added this in https://github.com/iximeow/yaxpeax-x86/blob/no-gods-no-/src/safer_unchecked.rs.

I'll leave this as draft while I investigate what's up and then mark it as ready once I get stuck on some of these.