### PR TITLE
Improve the error message emitted when a SIMD-incompatible CPU is used

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,7 +218,10 @@ use simdutf8::basic::imp::x86::sse42::ChunkedUtf8ValidatorImp;
         target_feature = "simd128"
     ))
 ))]
-fn please_compile_with_a_simd_compatible_cpu_setting_read_the_simdjsonrs_readme() -> ! {}
+compile_error!(concat!(
+    "Please compile with a simd compatible cpu setting. Read the simd-json readme for more:\n",
+    "    https://github.com/simd-lite/simd-json/blob/main/README.md",
+));
 
 mod stage2;
 /// simd-json JSON-DOM value


### PR DESCRIPTION
`simd-json` should be compiled on SIMD-compatible CPUs only. As such, it's a
good idea to ensure at compilation that the CPU is indeed compatible.

The previous check was performed thanks to a bunch of `#[cfg(...)]`
conditionals which would expand to incorrect code or not, hence raising a
compile error or not.

The error message was the following:

```
$ cargo c
    Checking simd-json v0.5.1 (/home/ssha/git/simd-json)
error[E0308]: mismatched types
   --> src/lib.rs:221:86
    |
221 | fn please_compile_with_a_simd_compatible_cpu_setting_read_the_simdjsonrs_readme() -> ! {}
    |    ----------------------------------------------------------------------------      ^ expected `!`, found `()`
    |    |
    |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note:   expected type `!`
            found unit type `()`

For more information about this error, try `rustc --explain E0308`.
error: could not compile `simd-json` due to previous error
```

The error message is... not very clear. The good news is that we have a simple
way to raising custom errors while compiling Rust code: the
[`compile_error`][1] macro. The error message now looks like:

```
$ cargo c
    Checking simd-json v0.5.1 (/home/ssha/git/tremor/simd-json)
error: Please compile with a simd compatible cpu setting. Read the simd-json readme for more:
           https://github.com/simd-lite/simd-json/blob/main/README.md
   --> src/lib.rs:221:1
    |
221 | / compile_error!(concat!(
222 | |     "Please compile with a simd compatible cpu setting. Read the simd-json readme for more:\n",
223 | |     "    https://github.com/simd-lite/simd-json/blob/main/README.md",
224 | | ));
    | |__^

error: could not compile `simd-json` due to previous error
```

The link to the `README` file is clickable on most modern terminals.

[1]: https://doc.rust-lang.org/std/macro.compile_error.html
