### PR TITLE
fix: Fix ub due to invalid alignment

### DIFF
--- a/src/numberparse.rs
+++ b/src/numberparse.rs
@@ -64,9 +64,8 @@ fn is_not_structural_or_whitespace_or_exponent_or_decimal(c: u8) -> bool {
 #[cfg(all(feature = "swar-number-parsing"))]
 #[cfg_attr(not(feature = "no-inline"), inline)]
 #[allow(clippy::cast_ptr_alignment)]
-fn is_made_of_eight_digits_fast(chars: &[u8]) -> bool {
-    // We know what we're doing right? :P
-    let val: u64 = unsafe { *(chars.as_ptr().cast::<u64>()) };
+fn is_made_of_eight_digits_fast(chars: [u8; 8]) -> bool {
+    let val = u64::from_ne_bytes(chars);
 
     ((val & 0xF0F0_F0F0_F0F0_F0F0)
         | (((val.wrapping_add(0x0606_0606_0606_0606)) & 0xF0F0_F0F0_F0F0_F0F0) >> 4))

--- a/src/numberparse/approx.rs
+++ b/src/numberparse/approx.rs
@@ -437,7 +437,11 @@ impl<'de> Deserializer<'de> {
                 // FIXME
                 // can we omit this: buf.len() - byte_count >= 8
 
-                if is_made_of_eight_digits_fast(unsafe { buf.get_kinda_unchecked(byte_count..) }) {
+                if is_made_of_eight_digits_fast(unsafe {
+                    buf.get_kinda_unchecked(byte_count..)
+                        .try_into()
+                        .unwrap_unchecked()
+                }) {
                     i = i.wrapping_mul(100_000_000).wrapping_add(u64::from(
                         parse_eight_digits_unrolled(unsafe {
                             buf.get_kinda_unchecked(byte_count..)

--- a/src/numberparse/correct.rs
+++ b/src/numberparse/correct.rs
@@ -82,7 +82,7 @@ impl<'de> Deserializer<'de> {
 
             #[cfg(feature = "swar-number-parsing")]
             {
-                if is_made_of_eight_digits_fast(&buf[idx..]) {
+                if is_made_of_eight_digits_fast(buf[idx..].try_into().unwrap()) {
                     num = 100_000_000_u64
                         .wrapping_mul(num)
                         .wrapping_add(u64::from(parse_eight_digits_unrolled(&buf[idx..])));


### PR DESCRIPTION
It is UB to cast a slice of bytes to `u64`. Not only the bytes, but the alignment must also be correct. 

Other than that I also think we should add compile flags to deal with the proper endianness.

I found this due to failing tests after a rustc update:

```
thread '<unnamed>' panicked at 'misaligned pointer dereference: address must be a multiple of 0x8 but is 0x7fd383839033', /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/simd-json-0.7.0/src/numberparse.rs:69:29
stack backtrace:
   0: rust_begin_unwind
             at /rustc/0599b6b931816ab46ab79072189075f543931cbd/library/std/src/panicking.rs:577:5
   1: core::panicking::panic_fmt
             at /rustc/0599b6b931816ab46ab79072189075f543931cbd/library/core/src/panicking.rs:67:14
   2: core::panicking::panic_misaligned_pointer_dereference
             at /rustc/0599b6b931816ab46ab79072189075f543931cbd/library/core/src/panicking.rs:174:5
   3: simd_json::numberparse::is_made_of_eight_digits_fast
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/simd-json-0.7.0/src/numberparse.rs:69:29
   4: simd_json::numberparse::correct::<impl simd_json::Deserializer>::parse_number
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/simd-json-0.7.0/src/numberparse/correct.rs:85:20
   5: simd_json::stage2::<impl simd_json::Deserializer>::build_tape
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/simd-json-0.7.0/src/stage2.rs:454:61
   6: simd_json::Deserializer::from_slice_with_buffers
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/simd-json-0.7.0/src/lib.rs:505:13
   7: simd_json::Deserializer::from_slice_with_buffer
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/simd-json-0.7.0/src/lib.rs:461:9
   8: simd_json::Deserializer::from_slice
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/simd-json-0.7.0/src/lib.rs:441:9
   9: simd_json::value::borrowed::to_value
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/simd-json-0.7.0/src/value/borrowed.rs:48:11
  10: polars_io::ndjson_core::ndjson::parse_impl
             at /home/ritchie46/code/polars/polars/polars-io/src/ndjson_core/ndjson.rs:260:51
  11: polars_io::ndjson_core::ndjson::parse_lines
             at /home/ritchie46/code/polars/polars/polars-io/src/ndjson_core/ndjson.rs:294:9
  12: polars_io::ndjson_core::ndjson::CoreJsonReader::parse_json::{{closure}}::{{closure}}
             at /home/ritchie46/code/polars/polars/polars-io/src/ndjson_core/ndjson.rs:216:29
  13: core::ops::function::impls::<impl core::ops::function::FnMut<A> for &F>::call_mut
             at /rustc/0599b6b931816ab46ab79072189075f543931cbd/library/core/src/ops/function.rs:274:13
  14: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &mut F>::call_once
             at /rustc/0599b6b931816ab46ab79072189075f543931cbd/library/core/src/ops/function.rs:310:13
  15: core::option::Option<T>::map
             at /rustc/0599b6b931816ab46ab79072189075f543931cbd/library/core/src/option.rs:1101:29
  16: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::next
             at /rustc/0599b6b931816ab46ab79072189075f543931cbd/library/core/src/iter/adapters/map.rs:103:9
  17: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::next
             at /rustc/0599b6b931816ab46ab79072189075f543931cbd/library/core/src/iter/adapters/map.rs:103:9
  18: <core::iter::adapters::take_while::TakeWhile<I,P> as core::iter::traits::iterator::Iterator>::next
             at /rustc/0599b6b931816ab46ab79072189075f543931cbd/library/core/src/iter/adapters/take_while.rs:46:21
  19: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::next
             at /rustc/0599b6b931816ab46ab79072189075f543931cbd/library/core/src/iter/adapters/map.rs:103:9
  20: alloc::vec::Vec<T,A>::extend_desugared
             at /rustc/0599b6b931816ab46ab79072189075f543931cbd/library/alloc/src/vec/mod.rs:2815:35
  21: <alloc::vec::Vec<T,A> as alloc::vec::spec_extend::SpecExtend<T,I>>::spec_extend
             at /rustc/0599b6b931816ab46ab79072189075f543931cbd/library/alloc/src/vec/spec_extend.rs:17:9
  22: <alloc::vec::Vec<T,A> as core::iter::traits::collect::Extend<T>>::extend
             at /rustc/0599b6b931816ab46ab79072189075f543931cbd/library/alloc/src/vec/mod.rs:2789:9
  23: <rayon::iter::extend::ListVecFolder<T> as rayon::iter::plumbing::Folder<T>>::consume_iter
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/extend.rs:73:9
  24: <rayon::iter::while_some::WhileSomeFolder<C> as rayon::iter::plumbing::Folder<core::option::Option<T>>>::consume_iter
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/while_some.rs:139:21
  25: <rayon::iter::map::MapFolder<C,F> as rayon::iter::plumbing::Folder<T>>::consume_iter
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/map.rs:248:21
  26: <rayon::iter::map::MapFolder<C,F> as rayon::iter::plumbing::Folder<T>>::consume_iter
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/map.rs:248:21
  27: rayon::iter::plumbing::Producer::fold_with
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/plumbing/mod.rs:110:9
  28: rayon::iter::plumbing::bridge_producer_consumer::helper
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/plumbing/mod.rs:438:13
  29: rayon::iter::plumbing::bridge_producer_consumer
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/plumbing/mod.rs:397:12
  30: <rayon::iter::plumbing::bridge::Callback<C> as rayon::iter::plumbing::ProducerCallback<I>>::callback
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/plumbing/mod.rs:373:13
  31: <rayon::vec::Drain<T> as rayon::iter::IndexedParallelIterator>::with_producer
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/vec.rs:147:13
  32: <rayon::vec::IntoIter<T> as rayon::iter::IndexedParallelIterator>::with_producer
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/vec.rs:83:9
  33: rayon::iter::plumbing::bridge
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/plumbing/mod.rs:357:12
  34: <rayon::vec::IntoIter<T> as rayon::iter::ParallelIterator>::drive_unindexed
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/vec.rs:58:9
  35: <rayon::iter::map::Map<I,F> as rayon::iter::ParallelIterator>::drive_unindexed
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/map.rs:49:9
  36: <rayon::iter::map::Map<I,F> as rayon::iter::ParallelIterator>::drive_unindexed
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/map.rs:49:9
  37: <rayon::iter::while_some::WhileSome<I> as rayon::iter::ParallelIterator>::drive_unindexed
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/while_some.rs:44:9
  38: rayon::iter::extend::<impl rayon::iter::ParallelExtend<T> for alloc::vec::Vec<T>>::par_extend
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/extend.rs:576:28
  39: rayon::iter::from_par_iter::collect_extended
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/from_par_iter.rs:17:5
  40: rayon::iter::from_par_iter::<impl rayon::iter::FromParallelIterator<T> for alloc::vec::Vec<T>>::from_par_iter
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/from_par_iter.rs:30:9
  41: rayon::iter::ParallelIterator::collect
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/mod.rs:2056:9
  42: rayon::result::<impl rayon::iter::FromParallelIterator<core::result::Result<T,E>> for core::result::Result<C,E>>::from_par_iter
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/result.rs:121:26
  43: rayon::iter::ParallelIterator::collect
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/mod.rs:2056:9
  44: polars_io::ndjson_core::ndjson::CoreJsonReader::parse_json::{{closure}}
             at /home/ritchie46/code/polars/polars/polars-io/src/ndjson_core/ndjson.rs:212:13
  45: rayon_core::thread_pool::ThreadPool::install::{{closure}}
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-core-1.11.0/src/thread_pool/mod.rs:110:40
  46: rayon_core::registry::Registry::in_worker_cold::{{closure}}::{{closure}}
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-core-1.11.0/src/registry.rs:541:21
  47: rayon_core::job::JobResult<T>::call::{{closure}}
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-core-1.11.0/src/job.rs:218:41
  48: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/0599b6b931816ab46ab79072189075f543931cbd/library/core/src/panic/unwind_safe.rs:271:9
  49: std::panicking::try::do_call
             at /rustc/0599b6b931816ab46ab79072189075f543931cbd/library/std/src/panicking.rs:485:40
  50: __rust_try
  51: std::panicking::try
             at /rustc/0599b6b931816ab46ab79072189075f543931cbd/library/std/src/panicking.rs:449:19
  52: std::panic::catch_unwind
             at /rustc/0599b6b931816ab46ab79072189075f543931cbd/library/std/src/panic.rs:140:14
  53: rayon_core::unwind::halt_unwinding
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-core-1.11.0/src/unwind.rs:17:5
  54: rayon_core::job::JobResult<T>::call
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-core-1.11.0/src/job.rs:218:15
  55: <rayon_core::job::StackJob<L,F,R> as rayon_core::job::Job>::execute
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-core-1.11.0/src/job.rs:120:32
  56: rayon_core::job::JobRef::execute
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-core-1.11.0/src/job.rs:64:9
  57: rayon_core::registry::WorkerThread::execute
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-core-1.11.0/src/registry.rs:874:9
  58: rayon_core::registry::WorkerThread::wait_until_cold
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-core-1.11.0/src/registry.rs:820:17
  59: rayon_core::registry::WorkerThread::wait_until
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-core-1.11.0/src/registry.rs:803:13
  60: rayon_core::registry::main_loop
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-core-1.11.0/src/registry.rs:948:5
  61: rayon_core::registry::ThreadBuilder::run
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-core-1.11.0/src/registry.rs:54:18
  62: <rayon_core::registry::DefaultSpawn as rayon_core::registry::ThreadSpawn>::spawn::{{closure}}
             at /home/ritchie46/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-core-1.11.0/src/registry.rs:99:20
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```