### PR TITLE
Use dtolnay's rust-toolchain GH Action

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,24 +30,27 @@ jobs:
           - '--features approx-number-parsing'
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
+    - uses: actions/checkout@v3
+
+    - uses: dtolnay/rust-toolchain@nightly
       with:
-        toolchain: nightly
-        override: true
         components: miri
+
     - name: Build
       env:
         RUSTFLAGS: ${{ matrix.rustflags }}
       run: cargo build ${{ matrix.features }}
+
     - name: Run tests
       env:
         RUSTFLAGS: ${{ matrix.rustflags }}
       run: cargo test ${{ matrix.features }}
+
     - name: Run miri
       env:
         RUSTFLAGS: ${{ matrix.rustflags }}
       run: cargo miri test ${{ matrix.features }}
+
     - name: Run tests (alloc)
       if: matrix.features == ''
       env:

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -17,14 +17,15 @@ jobs:
           - "-C target-cpu=native -C target-feature=-avx2,-pclmulqdq"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+
+      - uses: dtolnay/rust-toolchain@1.61 # do clippy chekcs with the minimum supported version
         with:
-          toolchain: 1.61 # do clippy chekcs with the minimum supported version
-          override: true
           components: rustfmt, clippy
+
       - name: Validate cargo format
         run: cargo fmt -- --check
+
       - name: Run clippy manually without annotations
         run: cargo clippy --all
   coverage:
@@ -45,21 +46,23 @@ jobs:
           - ""
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install deps
         run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config cmake zlib1g-dev
-      - uses: actions-rs/toolchain@v1
+
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable        
-          profile: minimal
           components: llvm-tools-preview
+
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+
       - name: Run codecov
         env:
           RUSTFLAGS: "-C target-cpu=native ${{ matrix.rustflags }}"
           PROPTEST_CASES: 512
         run: cargo llvm-cov --lcov --output-path lcov.txt --features no-inline${{ matrix.features }}
+
       - name: Generate matrix name
         run: |
               flags="${{ matrix.rustflags }}${{ matrix.features }}"
@@ -67,6 +70,7 @@ jobs:
               flags="${flags//[- ]/}"
               echo "$flags"
               echo "flags=$flags" >> $GITHUB_ENV
+
       - uses: codecov/codecov-action@v3
         with:
           files: ./lcov.txt # optional

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,19 +29,20 @@ jobs:
           - '--features approx-number-parsing'
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+    - uses: actions/checkout@v3
+
+    - uses: dtolnay/rust-toolchain@stable
+
     - name: Build
       env:
         RUSTFLAGS: ${{ matrix.rustflags }}
       run: cargo build ${{ matrix.features }}
+
     - name: Run tests
       env:
         RUSTFLAGS: ${{ matrix.rustflags }}
       run: cargo test ${{ matrix.features }}
+
     - name: Run tests (alloc)
       if: matrix.features == ''
       env:


### PR DESCRIPTION
This is an attempt to remove all the warnings related to deprecations in GitHub Actions.

The main reason for this change is because the Action-RS' toolchain is unmaintained since Nov 2020. This new GH Action now in use is maintained by one of the Rust Core Team members.