### PR TITLE
Improve error message for non-SIMD scenarios

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,6 @@
 [build]
 rustflags = ["-C", "target-cpu=native"]
+rustdocflags = ["-C", "target-cpu=native"]
 
 [target.wasm32-unknown-unknown]
 rustflags = ["-C", "target-feature=+simd128"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,8 @@ use simdutf8::basic::imp::x86::sse42::ChunkedUtf8ValidatorImp;
         target_feature = "simd128"
     ))
 ))]
-fn please_compile_with_a_simd_compatible_cpu_setting_read_the_simdjsonrs_readme() -> ! {}
+const _: () =
+    compile_error!("Please compile with a simd compatible cpu setting, read the simdjson README.");
 
 mod stage2;
 /// simd-json JSON-DOM value


### PR DESCRIPTION
Before:

```
error[E0308]: mismatched types
   --> (**masked**)/src/lib.rs:228:86
    |
228 | fn please_compile_with_a_simd_compatible_cpu_setting_read_the_simdjsonrs_readme() -> ! {}
    |    ----------------------------------------------------------------------------      ^ expected `!`, found `()`
    |    |
    |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note:   expected type `!`
            found unit type `()`

For more information about this error, try `rustc --explain E0308`.
error: could not compile `simd-json` due to previous error
```

After:

```
error: Please compile with a simd compatible cpu setting, read the simdjson README.
   --> (**masked**)/src/lib.rs:229:5
    |
229 |     compile_error!("Please compile with a simd compatible cpu setting, read the simdjson README.");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: could not compile `simd-json` due to previous error
```

Much cleaner, without distracting noise.