### PR TITLE
Fix setting too much of the alligned buffer to 0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -487,8 +487,8 @@ impl<'de> Deserializer<'de> {
         unsafe {
             std::ptr::copy_nonoverlapping(input.as_ptr(), input_buffer.as_mut_ptr(), len);
 
-            let to_fill = input_buffer.capacity() - len;
-            std::ptr::write_bytes(input_buffer.as_mut_ptr().add(len), 0, to_fill);
+            // ensure we have a 0 to terminate the buffer
+            std::ptr::write(input_buffer.as_mut_ptr().add(len), 0);
 
             input_buffer.set_len(input_buffer.capacity());
         };


### PR DESCRIPTION
We don't need to set the entire alligned buffer to 0, instead a single 0 is enough to mark that we terminate the json string