### PR TITLE
fix: initialize bytes up to `len` of `AlignedBuf`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,7 +248,7 @@ mod known_key;
 pub use known_key::{Error as KnownKeyError, KnownKey};
 
 pub use crate::tape::{Node, Tape};
-use std::alloc::{alloc, handle_alloc_error, Layout};
+use std::alloc::{alloc_zeroed, handle_alloc_error, Layout};
 use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
 
@@ -489,8 +489,8 @@ impl<'de> Deserializer<'de> {
 
             // ensure we have a 0 to terminate the buffer
             std::ptr::write(input_buffer.as_mut_ptr().add(len), 0);
-            // safety: we just initialized all bytes up until `len`
-            input_buffer.set_len(len);
+
+            input_buffer.set_len(input_buffer.capacity());
         };
 
         let s1_result: std::result::Result<Vec<u32>, ErrorType> =
@@ -710,7 +710,7 @@ impl AlignedBuf {
         if mem::size_of::<usize>() < 8 && capacity > isize::MAX as usize {
             Self::capacity_overflow()
         }
-        let inner = match unsafe { NonNull::new(alloc(layout)) } {
+        let inner = match unsafe { NonNull::new(alloc_zeroed(layout)) } {
             Some(ptr) => ptr,
             None => handle_alloc_error(layout),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,7 +490,7 @@ impl<'de> Deserializer<'de> {
             // ensure we have a 0 to terminate the buffer
             std::ptr::write(input_buffer.as_mut_ptr().add(len), 0);
 
-            // initialize all remaingin bytes
+            // initialize all remaining bytes
             if len < input_buffer.capacity() {
                 for i in len..input_buffer.capacity() {
                     std::ptr::write(input_buffer.as_mut_ptr().add(i), 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -489,8 +489,8 @@ impl<'de> Deserializer<'de> {
 
             // ensure we have a 0 to terminate the buffer
             std::ptr::write(input_buffer.as_mut_ptr().add(len), 0);
-
-            input_buffer.set_len(input_buffer.capacity());
+            // safety: we just initialized all bytes up until `len`
+            input_buffer.set_len(len);
         };
 
         let s1_result: std::result::Result<Vec<u32>, ErrorType> =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -487,14 +487,10 @@ impl<'de> Deserializer<'de> {
         unsafe {
             std::ptr::copy_nonoverlapping(input.as_ptr(), input_buffer.as_mut_ptr(), len);
 
-            // ensure we have a 0 to terminate the buffer
-            std::ptr::write(input_buffer.as_mut_ptr().add(len), 0);
-
             // initialize all remaining bytes
-            if len < input_buffer.capacity() {
-                for i in len..input_buffer.capacity() {
-                    std::ptr::write(input_buffer.as_mut_ptr().add(i), 0);
-                }
+            // this also ensures we have a 0 to terminate the buffer
+            for i in len..input_buffer.capacity() {
+                std::ptr::write(input_buffer.as_mut_ptr().add(i), 0);
             }
 
             // safety: all bytes are initialized


### PR DESCRIPTION
It is UB to create `Vec` with unitialized bytes. 

This fixes that by ensuring we only `set_len` to the length we have written.

Adding a few `dbg!` statements showing the `len` and `capacity` whilst reading this [file](https://gist.githubusercontent.com/getorca/d3a6460f0d14b573c1d38322828d34d8/raw/20a934b9671c99d96f14461521493abf4d08ae31/test.jsonl) showed they where off. 

```
[/home/ritchie46/Downloads/simd-json/src/lib.rs:492] len = 1432
[/home/ritchie46/Downloads/simd-json/src/lib.rs:492] input_buffer.capacity = 1496
[/home/ritchie46/Downloads/simd-json/src/lib.rs:492] len = 1431
[/home/ritchie46/Downloads/simd-json/src/lib.rs:492] input_buffer.capacity = 1495
```

Reading that file in valgrind also showed that we read the uninitialized bytes confirming UB.

Valgrind output:

```
==180409== Memcheck, a memory error detector
==180409== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==180409== Using Valgrind-3.20.0 and LibVEX; rerun with -h for copyright info
==180409== Command: ./target/debug/memcheck
==180409== 
==180409== Conditional jump or move depends on uninitialised value(s)
==180409==    at 0x363B96: parse_str_ (deser.rs:130)
==180409==    by 0x363B96: simd_json::stage2::<impl simd_json::Deserializer>::build_tape (stage2.rs:414)
==180409==    by 0x38391C: simd_json::Deserializer::from_slice_with_buffers (lib.rs:507)
==180409==    by 0x383425: simd_json::Deserializer::from_slice_with_buffer (lib.rs:463)
==180409==    by 0x383312: simd_json::Deserializer::from_slice (lib.rs:443)
==180409==    by 0x35145B: simd_json::value::borrowed::to_value (borrowed.rs:49)
==180409==    by 0x31596D: polars_json::ndjson::file::parse_value (file.rs:91)
==180409==    by 0x2DCB58: polars_json::ndjson::file::infer (file.rs:117)
==180409==    by 0x2CD455: polars_io::ndjson::core::CoreJsonReader::new (core.rs:175)
==180409==    by 0x2B5911: <polars_io::json::JsonReader<R> as polars_io::SerReader<R>>::finish (mod.rs:272)
==180409==    by 0x2B4024: memcheck::issue::run (issue.rs:11)
==180409==    by 0x2B3E2A: memcheck::main::{{closure}} (main.rs:16)
==180409==    by 0x2B3D8D: memcheck::main (main.rs:15)
==180409== 

```

## Background

I got to this because I have very strange bugs upstream in polars which I cannot replicate and only occur when we compile with fat linking and all optimizations. This made me suspect UB.

https://github.com/pola-rs/polars/issues/9791

https://github.com/pola-rs/polars/issues/10034