### PR TITLE
Fix docs build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,6 @@ readme = "README.md"
 documentation = "https://docs.rs/simd-json"
 rust-version = "1.61"
 
-[package.metadata.docs.rs]
-features = ["docsrs"]
-
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
 


### PR DESCRIPTION
Right now, local builds of the docs for simd-json fail due to the "target-cpu" compilation error. This unfortunately also happens on docs.rs, although one would it expect it doesn't. This fixes it by changing the `cfg(docsrs)` to `cfg(doc)`, which should apply both to local doc builds as well as when publishing to docs.rs.