### PR TITLE
refactor tape::Node<'input>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -875,7 +875,7 @@ mod tests {
         let mut d = String::from("[]");
         let d = unsafe { d.as_bytes_mut() };
         let simd = Deserializer::from_slice(d).expect("");
-        assert_eq!(simd.tape[1], Node::Array(0, 2));
+        assert_eq!(simd.tape[1], Node::Array { len: 0, end: 2 });
     }
 
     #[test]
@@ -883,7 +883,7 @@ mod tests {
         let mut d = String::from("[1]");
         let d = unsafe { d.as_bytes_mut() };
         let simd = Deserializer::from_slice(d).expect("");
-        assert_eq!(simd.tape[1], Node::Array(1, 3));
+        assert_eq!(simd.tape[1], Node::Array { len: 1, end: 3 });
     }
 
     #[test]
@@ -891,7 +891,7 @@ mod tests {
         let mut d = String::from("[1,2]");
         let d = unsafe { d.as_bytes_mut() };
         let simd = Deserializer::from_slice(d).expect("");
-        assert_eq!(simd.tape[1], Node::Array(2, 4));
+        assert_eq!(simd.tape[1], Node::Array { len: 2, end: 4 });
     }
 
     #[test]
@@ -899,8 +899,8 @@ mod tests {
         let mut d = String::from(" [ 1 , [ 3 ] , 2 ]");
         let d = unsafe { d.as_bytes_mut() };
         let simd = Deserializer::from_slice(d).expect("");
-        assert_eq!(simd.tape[1], Node::Array(3, 6));
-        assert_eq!(simd.tape[3], Node::Array(1, 5));
+        assert_eq!(simd.tape[1], Node::Array { len: 3, end: 6 });
+        assert_eq!(simd.tape[3], Node::Array { len: 1, end: 5 });
     }
 
     #[test]
@@ -908,8 +908,29 @@ mod tests {
         let mut d = String::from("[[],null,null]");
         let d = unsafe { d.as_bytes_mut() };
         let simd = Deserializer::from_slice(d).expect("");
-        assert_eq!(simd.tape[1], Node::Array(3, 5));
-        assert_eq!(simd.tape[2], Node::Array(0, 3));
+        assert_eq!(simd.tape[1], Node::Array { len: 3, end: 5 });
+        assert_eq!(simd.tape[2], Node::Array { len: 0, end: 3 });
+    }
+
+    #[test]
+    fn test_tape_object_escaped() {
+        let mut d = String::from(r#" { "hell\"o": 1 , "b": [ 1, 2, 3 ] }"#);
+        let d = unsafe { d.as_bytes_mut() };
+        let simd = Deserializer::from_slice(d).expect("");
+        assert_eq!(
+            simd.tape,
+            [
+                Node::Static(StaticNode::Null),
+                Node::Object { len: 2, end: 9 },
+                Node::String(r#"hell"o"#), // <-- This is already escaped
+                Node::Static(StaticNode::I64(1)),
+                Node::String("b"),
+                Node::Array { len: 3, end: 9 },
+                Node::Static(StaticNode::I64(1)),
+                Node::Static(StaticNode::I64(2)),
+                Node::Static(StaticNode::I64(3))
+            ]
+        );
     }
 
     #[test]

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -29,8 +29,8 @@ where
             Node::Static(StaticNode::U64(n)) => visitor.visit_u64(n),
             #[cfg(feature = "128bit")]
             Node::Static(StaticNode::U128(n)) => visitor.visit_u128(n),
-            Node::Array(len, _) => visitor.visit_seq(CommaSeparated::new(self, len)),
-            Node::Object(len, _) => visitor.visit_map(CommaSeparated::new(self, len)),
+            Node::Array { len, end: _ } => visitor.visit_seq(CommaSeparated::new(self, len)),
+            Node::Object { len, end: _ } => visitor.visit_map(CommaSeparated::new(self, len)),
         }
     }
 
@@ -234,7 +234,7 @@ where
         V: Visitor<'de>,
     {
         // Parse the opening bracket of the sequence.
-        if let Ok(Node::Array(len, _)) = self.next() {
+        if let Ok(Node::Array { len, end: _ }) = self.next() {
             // Give the visitor access to each element of the sequence.
             visitor.visit_seq(CommaSeparated::new(self, len))
         } else {
@@ -297,7 +297,7 @@ where
         V: Visitor<'de>,
     {
         // Parse the opening bracket of the sequence.
-        if let Ok(Node::Object(len, _)) = self.next() {
+        if let Ok(Node::Object { len, end: _ }) = self.next() {
             // Give the visitor access to each element of the sequence.
             visitor.visit_map(CommaSeparated::new(self, len))
         } else {
@@ -317,8 +317,8 @@ where
     {
         match self.next() {
             // Give the visitor access to each element of the sequence.
-            Ok(Node::Object(len, _)) => visitor.visit_map(CommaSeparated::new(self, len)),
-            Ok(Node::Array(len, _)) => visitor.visit_seq(CommaSeparated::new(self, len)),
+            Ok(Node::Object { len, end: _ }) => visitor.visit_map(CommaSeparated::new(self, len)),
+            Ok(Node::Array { len, end: _ }) => visitor.visit_seq(CommaSeparated::new(self, len)),
             _ => Err(Deserializer::error(ErrorType::ExpectedMap)),
         }
     }
@@ -335,7 +335,7 @@ where
     {
         // Parse the opening bracket of the sequence.
         match self.next() {
-            Ok(Node::Object(len, _)) if len == 1 => {
+            Ok(Node::Object { len, end: _ }) if len == 1 => {
                 // Give the visitor access to each element of the sequence.
                 // let value = ri!(visitor.visit_enum(VariantAccess::new(self)));
                 visitor.visit_enum(VariantAccess::new(self))

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -29,8 +29,8 @@ where
             Node::Static(StaticNode::U64(n)) => visitor.visit_u64(n),
             #[cfg(feature = "128bit")]
             Node::Static(StaticNode::U128(n)) => visitor.visit_u128(n),
-            Node::Array { len, end: _ } => visitor.visit_seq(CommaSeparated::new(self, len)),
-            Node::Object { len, end: _ } => visitor.visit_map(CommaSeparated::new(self, len)),
+            Node::Array { len, count: _ } => visitor.visit_seq(CommaSeparated::new(self, len)),
+            Node::Object { len, count: _ } => visitor.visit_map(CommaSeparated::new(self, len)),
         }
     }
 
@@ -234,7 +234,7 @@ where
         V: Visitor<'de>,
     {
         // Parse the opening bracket of the sequence.
-        if let Ok(Node::Array { len, end: _ }) = self.next() {
+        if let Ok(Node::Array { len, count: _ }) = self.next() {
             // Give the visitor access to each element of the sequence.
             visitor.visit_seq(CommaSeparated::new(self, len))
         } else {
@@ -297,7 +297,7 @@ where
         V: Visitor<'de>,
     {
         // Parse the opening bracket of the sequence.
-        if let Ok(Node::Object { len, end: _ }) = self.next() {
+        if let Ok(Node::Object { len, count: _ }) = self.next() {
             // Give the visitor access to each element of the sequence.
             visitor.visit_map(CommaSeparated::new(self, len))
         } else {
@@ -317,8 +317,8 @@ where
     {
         match self.next() {
             // Give the visitor access to each element of the sequence.
-            Ok(Node::Object { len, end: _ }) => visitor.visit_map(CommaSeparated::new(self, len)),
-            Ok(Node::Array { len, end: _ }) => visitor.visit_seq(CommaSeparated::new(self, len)),
+            Ok(Node::Object { len, count: _ }) => visitor.visit_map(CommaSeparated::new(self, len)),
+            Ok(Node::Array { len, count: _ }) => visitor.visit_seq(CommaSeparated::new(self, len)),
             _ => Err(Deserializer::error(ErrorType::ExpectedMap)),
         }
     }
@@ -335,7 +335,7 @@ where
     {
         // Parse the opening bracket of the sequence.
         match self.next() {
-            Ok(Node::Object { len, end: _ }) if len == 1 => {
+            Ok(Node::Object { len, count: _ }) if len == 1 => {
                 // Give the visitor access to each element of the sequence.
                 // let value = ri!(visitor.visit_enum(VariantAccess::new(self)));
                 visitor.visit_enum(VariantAccess::new(self))

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -299,7 +299,7 @@ impl<'de> Deserializer<'de> {
                 }
 
                 last_start = r_i;
-                insert_res!(Node::Object(0, 0));
+                insert_res!(Node::Object { len: 0, end: 0 });
 
                 depth += 1;
                 cnt = 1;
@@ -326,7 +326,7 @@ impl<'de> Deserializer<'de> {
                 }
 
                 last_start = r_i;
-                insert_res!(Node::Array(0, 0));
+                insert_res!(Node::Array { len: 0, end: 0 });
 
                 depth += 1;
                 cnt = 1;
@@ -459,7 +459,7 @@ impl<'de> Deserializer<'de> {
                                 s.add(depth).write((StackState::Object, last_start, cnt));
                             }
                             last_start = r_i;
-                            insert_res!(Node::Object(0, 0));
+                            insert_res!(Node::Object { len: 0, end: 0 });
                             depth += 1;
                             cnt = 1;
                             object_begin!();
@@ -470,7 +470,7 @@ impl<'de> Deserializer<'de> {
                                 s.add(depth).write((StackState::Object, last_start, cnt));
                             }
                             last_start = r_i;
-                            insert_res!(Node::Array(0, 0));
+                            insert_res!(Node::Array { len: 0, end: 0 });
                             depth += 1;
                             cnt = 1;
                             array_begin!();
@@ -488,8 +488,14 @@ impl<'de> Deserializer<'de> {
                     depth -= 1;
                     unsafe {
                         match *res.as_mut_ptr().add(last_start) {
-                            Node::Array(ref mut len, ref mut end)
-                            | Node::Object(ref mut len, ref mut end) => {
+                            Node::Array {
+                                ref mut len,
+                                ref mut end,
+                            }
+                            | Node::Object {
+                                ref mut len,
+                                ref mut end,
+                            } => {
                                 *len = cnt;
                                 *end = r_i;
                             }
@@ -565,7 +571,7 @@ impl<'de> Deserializer<'de> {
                                 s.add(depth).write((StackState::Array, last_start, cnt));
                             }
                             last_start = r_i;
-                            insert_res!(Node::Object(0, 0));
+                            insert_res!(Node::Object { len: 0, end: 0 });
                             depth += 1;
                             cnt = 1;
                             object_begin!();
@@ -576,7 +582,7 @@ impl<'de> Deserializer<'de> {
                                 s.add(depth).write((StackState::Array, last_start, cnt));
                             }
                             last_start = r_i;
-                            insert_res!(Node::Array(0, 0));
+                            insert_res!(Node::Array { len: 0, end: 0 });
                             depth += 1;
                             cnt = 1;
                             array_begin!();

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -299,7 +299,7 @@ impl<'de> Deserializer<'de> {
                 }
 
                 last_start = r_i;
-                insert_res!(Node::Object { len: 0, end: 0 });
+                insert_res!(Node::Object { len: 0, count: 0 });
 
                 depth += 1;
                 cnt = 1;
@@ -326,7 +326,7 @@ impl<'de> Deserializer<'de> {
                 }
 
                 last_start = r_i;
-                insert_res!(Node::Array { len: 0, end: 0 });
+                insert_res!(Node::Array { len: 0, count: 0 });
 
                 depth += 1;
                 cnt = 1;
@@ -459,7 +459,7 @@ impl<'de> Deserializer<'de> {
                                 s.add(depth).write((StackState::Object, last_start, cnt));
                             }
                             last_start = r_i;
-                            insert_res!(Node::Object { len: 0, end: 0 });
+                            insert_res!(Node::Object { len: 0, count: 0 });
                             depth += 1;
                             cnt = 1;
                             object_begin!();
@@ -470,7 +470,7 @@ impl<'de> Deserializer<'de> {
                                 s.add(depth).write((StackState::Object, last_start, cnt));
                             }
                             last_start = r_i;
-                            insert_res!(Node::Array { len: 0, end: 0 });
+                            insert_res!(Node::Array { len: 0, count: 0 });
                             depth += 1;
                             cnt = 1;
                             array_begin!();
@@ -490,14 +490,14 @@ impl<'de> Deserializer<'de> {
                         match *res.as_mut_ptr().add(last_start) {
                             Node::Array {
                                 ref mut len,
-                                ref mut end,
+                                count: ref mut end,
                             }
                             | Node::Object {
                                 ref mut len,
-                                ref mut end,
+                                count: ref mut end,
                             } => {
                                 *len = cnt;
-                                *end = r_i;
+                                *end = r_i - last_start - 1;
                             }
                             _ => unreachable!(),
                         };
@@ -571,7 +571,7 @@ impl<'de> Deserializer<'de> {
                                 s.add(depth).write((StackState::Array, last_start, cnt));
                             }
                             last_start = r_i;
-                            insert_res!(Node::Object { len: 0, end: 0 });
+                            insert_res!(Node::Object { len: 0, count: 0 });
                             depth += 1;
                             cnt = 1;
                             object_begin!();
@@ -582,7 +582,7 @@ impl<'de> Deserializer<'de> {
                                 s.add(depth).write((StackState::Array, last_start, cnt));
                             }
                             last_start = r_i;
-                            insert_res!(Node::Array { len: 0, end: 0 });
+                            insert_res!(Node::Array { len: 0, count: 0 });
                             depth += 1;
                             cnt = 1;
                             array_begin!();

--- a/src/value.rs
+++ b/src/value.rs
@@ -128,8 +128,8 @@ where
         match unsafe { self.de.next_() } {
             Node::Static(s) => Value::from(s),
             Node::String(s) => Value::from(s),
-            Node::Array(len, _) => self.parse_array(len),
-            Node::Object(len, _) => self.parse_map(len),
+            Node::Array { len, end: _ } => self.parse_array(len),
+            Node::Object { len, end: _ } => self.parse_map(len),
         }
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -128,8 +128,8 @@ where
         match unsafe { self.de.next_() } {
             Node::Static(s) => Value::from(s),
             Node::String(s) => Value::from(s),
-            Node::Array { len, end: _ } => self.parse_array(len),
-            Node::Object { len, end: _ } => self.parse_map(len),
+            Node::Array { len, count: _ } => self.parse_array(len),
+            Node::Object { len, count: _ } => self.parse_map(len),
         }
     }
 

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -178,6 +178,23 @@ impl<'value> Mutable for Value<'value> {
             _ => None,
         }
     }
+    /// Get mutable access to a map.
+    ///
+    /// ```rust
+    /// use simd_json::*;
+    ///
+    /// let mut object: BorrowedValue = json!({
+    ///   "answer": 23,
+    ///   "key": 7
+    /// }).into();
+    /// assert_eq!(object["answer"], 23);
+    ///
+    /// if let Some(inner) = object.as_object_mut() {
+    ///   inner.insert("value".into(), BorrowedValue::from(json!({"nested": 42})));
+    /// }
+    /// assert_eq!(object["value"], json!({"nested": 42}));
+    ///
+    /// ```
     #[inline]
     #[must_use]
     fn as_object_mut(&mut self) -> Option<&mut Object<'value>> {
@@ -400,8 +417,8 @@ impl<'de> BorrowDeserializer<'de> {
         match unsafe { self.0.next_() } {
             Node::Static(s) => Value::Static(s),
             Node::String(s) => Value::from(s),
-            Node::Array { len, end: _ } => self.parse_array(len),
-            Node::Object { len, end: _ } => self.parse_map(len),
+            Node::Array { len, count: _ } => self.parse_array(len),
+            Node::Object { len, count: _ } => self.parse_map(len),
         }
     }
 

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -400,8 +400,8 @@ impl<'de> BorrowDeserializer<'de> {
         match unsafe { self.0.next_() } {
             Node::Static(s) => Value::Static(s),
             Node::String(s) => Value::from(s),
-            Node::Array(len, _) => self.parse_array(len),
-            Node::Object(len, _) => self.parse_map(len),
+            Node::Array { len, end: _ } => self.parse_array(len),
+            Node::Object { len, end: _ } => self.parse_map(len),
         }
     }
 

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -339,8 +339,8 @@ impl<'de> OwnedDeserializer<'de> {
         match unsafe { self.de.next_() } {
             Node::Static(s) => Value::Static(s),
             Node::String(s) => Value::from(s),
-            Node::Array(len, _) => self.parse_array(len),
-            Node::Object(len, _) => self.parse_map(len),
+            Node::Array { len, end: _ } => self.parse_array(len),
+            Node::Object { len, end: _ } => self.parse_map(len),
         }
     }
 

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -339,8 +339,8 @@ impl<'de> OwnedDeserializer<'de> {
         match unsafe { self.de.next_() } {
             Node::Static(s) => Value::Static(s),
             Node::String(s) => Value::from(s),
-            Node::Array { len, end: _ } => self.parse_array(len),
-            Node::Object { len, end: _ } => self.parse_map(len),
+            Node::Array { len, count: _ } => self.parse_array(len),
+            Node::Object { len, count: _ } => self.parse_map(len),
         }
     }
 

--- a/src/value/tape.rs
+++ b/src/value/tape.rs
@@ -13,11 +13,21 @@ pub enum Node<'input> {
     /// An `Object` with the given `size` starts here.
     /// the following values are keys and values, alternating
     /// however values can be nested and have a length themselves.
-    Object(usize, usize),
+    Object {
+        /// The number of keys in the object
+        len: usize,
+        /// The end index of the object in the `Vec<Node>` array
+        end: usize,
+    },
     /// An array with a given size starts here. The next `size`
     /// elements belong to it - values can be nested and have a
     /// `size` of their own.
-    Array(usize, usize),
+    Array {
+        /// The number of elements in the array
+        len: usize,
+        /// The end index of the array in the `Vec<Node>` array
+        end: usize,
+    },
     /// A static value that is interned into the tape, it can
     /// be directly taken and isn't nested.
     Static(StaticNode),

--- a/src/value/tape.rs
+++ b/src/value/tape.rs
@@ -16,8 +16,8 @@ pub enum Node<'input> {
     Object {
         /// The number of keys in the object
         len: usize,
-        /// The end index of the object in the `Vec<Node>` array
-        end: usize,
+        /// The total number of nodes in the object, including subelements.
+        count: usize,
     },
     /// An array with a given size starts here. The next `size`
     /// elements belong to it - values can be nested and have a
@@ -25,8 +25,8 @@ pub enum Node<'input> {
     Array {
         /// The number of elements in the array
         len: usize,
-        /// The end index of the array in the `Vec<Node>` array
-        end: usize,
+        /// The total number of nodes in the array, including subelements.
+        count: usize,
     },
     /// A static value that is interned into the tape, it can
     /// be directly taken and isn't nested.


### PR DESCRIPTION
The two parameters in Object and Array are undocumented and not
understood without looking at the source code.
Refactor to be more explanatory and add docs


I'm not sure of the usefulness of `end`. It's not used currently and maybe can be removed?
