### PR TITLE
fix typos in explanation text in source files

### DIFF
--- a/src/impls/avx2/stage1.rs
+++ b/src/impls/avx2/stage1.rs
@@ -43,7 +43,7 @@ impl Stage1Parse for SimdInput {
     type Utf8Validator = simdutf8::basic::imp::x86::avx2::ChunkedUtf8ValidatorImp;
     type SimdRepresentation = __m256i;
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    // _mm256_loadu_si256 does not need allignment
+    // _mm256_loadu_si256 does not need alignment
     #[allow(clippy::cast_ptr_alignment)]
     #[target_feature(enable = "avx2")]
     unsafe fn new(ptr: &[u8]) -> Self {
@@ -189,8 +189,8 @@ impl Stage1Parse for SimdInput {
 
         // We're doing some trickery here.
         // We reserve 64 extra entries, because we've at most 64 bit to set
-        // then we trunctate the base to the next base (that we calcuate above)
-        // We later indiscriminatory writre over the len we set but that's OK
+        // then we truncate the base to the next base (that we calculated above)
+        // We later indiscriminatory write over the len we set but that's OK
         // since we ensure we reserve the needed space
         base.reserve(64);
         let final_len = l + cnt;

--- a/src/impls/native/deser.rs
+++ b/src/impls/native/deser.rs
@@ -77,7 +77,7 @@ pub(crate) unsafe fn parse_str<'invoke, 'de>(
                         InvalidUnicodeCodepoint,
                     ));
                 }
-                // We have to substract one since we're already moving to the next character at the end of the loop
+                // We have to subtract one since we're already moving to the next character at the end of the loop
                 src_i += src_offset - 1;
             } else {
                 let escape_result: u8 = *ESCAPE_MAP.get_kinda_unchecked(escape_char as usize);

--- a/src/impls/native/stage1.rs
+++ b/src/impls/native/stage1.rs
@@ -439,8 +439,8 @@ impl Stage1Parse for SimdInput {
 
         // We're doing some trickery here.
         // We reserve 64 extra entries, because we've at most 64 bit to set
-        // then we trunctate the base to the next base (that we calcuate above)
-        // We later indiscriminatory writre over the len we set but that's OK
+        // then we truncate the base to the next base (that we calculated above)
+        // We later indiscriminatory write over the len we set but that's OK
         // since we ensure we reserve the needed space
         base.reserve(64);
         let final_len = l + cnt;

--- a/src/impls/neon/stage1.rs
+++ b/src/impls/neon/stage1.rs
@@ -184,8 +184,8 @@ impl Stage1Parse for SimdInput {
 
         // We're doing some trickery here.
         // We reserve 64 extra entries, because we've at most 64 bit to set
-        // then we trunctate the base to the next base (that we calcuate above)
-        // We later indiscriminatory writre over the len we set but that's OK
+        // then we truncate the base to the next base (that we calculated above)
+        // We later indiscriminatory write over the len we set but that's OK
         // since we ensure we reserve the needed space
         base.reserve(64);
         let final_len = l + cnt;

--- a/src/impls/portable/stage1.rs
+++ b/src/impls/portable/stage1.rs
@@ -123,8 +123,8 @@ impl Stage1Parse for SimdInput {
 
         // We're doing some trickery here.
         // We reserve 64 extra entries, because we've at most 64 bit to set
-        // then we trunctate the base to the next base (that we calcuate above)
-        // We later indiscriminatory writre over the len we set but that's OK
+        // then we truncate the base to the next base (that we calculated above)
+        // We later indiscriminatory write over the len we set but that's OK
         // since we ensure we reserve the needed space
         base.reserve(64);
         let final_len = l + cnt;

--- a/src/impls/simd128/deser.rs
+++ b/src/impls/simd128/deser.rs
@@ -34,7 +34,7 @@ pub(crate) fn parse_str<'invoke, 'de>(
     let mut len = src_i;
     loop {
         let v = unsafe {
-            // v128_load requires no allignment
+            // v128_load requires no alignment
             #[allow(clippy::cast_ptr_alignment)]
             v128_load(src.as_ptr().add(src_i).cast::<v128>())
         };
@@ -83,13 +83,13 @@ pub(crate) fn parse_str<'invoke, 'de>(
     // To be more conform with upstream
     loop {
         let v = unsafe {
-            // v128_load requires no allignment
+            // v128_load requires no alignment
             #[allow(clippy::cast_ptr_alignment)]
             v128_load(src.as_ptr().add(src_i).cast::<v128>())
         };
 
         unsafe {
-            // v128_store requires no allignment
+            // v128_store requires no alignment
             #[allow(clippy::cast_ptr_alignment)]
             v128_store(buffer.as_mut_ptr().add(dst_i).cast::<v128>(), v);
         };

--- a/src/impls/simd128/stage1.rs
+++ b/src/impls/simd128/stage1.rs
@@ -169,8 +169,8 @@ impl Stage1Parse for SimdInput {
 
         // We're doing some trickery here.
         // We reserve 64 extra entries, because we've at most 64 bit to set
-        // then we trunctate the base to the next base (that we calcuate above)
-        // We later indiscriminatory writre over the len we set but that's OK
+        // then we truncate the base to the next base (that we calculated above)
+        // We later indiscriminatory write over the len we set but that's OK
         // since we ensure we reserve the needed space
         base.reserve(64);
         let final_len = l + cnt;
@@ -187,7 +187,7 @@ impl Stage1Parse for SimdInput {
 
             let v = u32x4(v0, v1, v2, v3);
             let v = u32x4_add(idx_64_v, v);
-            // v128_store requires no allignment
+            // v128_store requires no alignment
             #[allow(clippy::cast_ptr_alignment)]
             v128_store(base.as_mut_ptr().add(l).cast::<v128>(), v);
             l += 4;

--- a/src/impls/sse42/deser.rs
+++ b/src/impls/sse42/deser.rs
@@ -36,7 +36,7 @@ pub(crate) unsafe fn parse_str<'invoke, 'de>(
     let mut src_i: usize = 0;
     let mut len = src_i;
     loop {
-        // _mm_loadu_si128 does not require alignmnet
+        // _mm_loadu_si128 does not require alignment
         #[allow(clippy::cast_ptr_alignment)]
         let v: __m128i =
             unsafe { _mm_loadu_si128(src.as_ptr().add(src_i).cast::<arch::__m128i>()) };
@@ -89,11 +89,11 @@ pub(crate) unsafe fn parse_str<'invoke, 'de>(
 
     // To be more conform with upstream
     loop {
-        // _mm_loadu_si128 does not require alignmnet
+        // _mm_loadu_si128 does not require alignment
         #[allow(clippy::cast_ptr_alignment)]
         let v: __m128i = _mm_loadu_si128(src.as_ptr().add(src_i).cast::<arch::__m128i>());
 
-        // _mm_storeu_si128 does not require alignmnet
+        // _mm_storeu_si128 does not require alignment
         #[allow(clippy::cast_ptr_alignment)]
         _mm_storeu_si128(buffer.as_mut_ptr().add(dst_i).cast::<arch::__m128i>(), v);
 

--- a/src/impls/sse42/stage1.rs
+++ b/src/impls/sse42/stage1.rs
@@ -246,8 +246,8 @@ impl Stage1Parse for SimdInput {
 
         // We're doing some trickery here.
         // We reserve 64 extra entries, because we've at most 64 bit to set
-        // then we trunctate the base to the next base (that we calcuate above)
-        // We later indiscriminatory writre over the len we set but that's OK
+        // then we truncate the base to the next base (that we calculated above)
+        // We later indiscriminatory write over the len we set but that's OK
         // since we ensure we reserve the needed space
         base.reserve(64);
         let final_len = l + cnt;

--- a/src/known_key.rs
+++ b/src/known_key.rs
@@ -9,7 +9,7 @@ use ahash::{AHasher, RandomState};
 use once_cell::sync::OnceCell;
 static NOT_RANDOM: OnceCell<RandomState> = OnceCell::new();
 
-/// `AHash` `BuildHasher` thast uses a startup initialized random state for known keys
+/// `AHash` `BuildHasher` that uses a startup initialized random state for known keys
 #[derive(Clone)]
 pub struct NotSoRandomState(RandomState);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,7 +337,7 @@ pub(crate) trait Stage1Parse {
         // following it.
 
         // a qualified predecessor is something that can happen 1 position before an
-        // psuedo-structural character
+        // pseudo-structural character
         let pseudo_pred: u64 = structurals | whitespace;
 
         let shifted_pseudo_pred: u64 = (pseudo_pred << 1) | *prev_iter_ends_pseudo_pred;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -72,7 +72,7 @@ where
 ///
 /// # Safety
 ///
-/// This function mutates the string passed into it, it's a convinience wrapper around `from_slice`,
+/// This function mutates the string passed into it, it's a convenience wrapper around `from_slice`,
 /// holding the same guarantees as `str::as_bytes_mut` in that after the call &str might include
 /// invalid utf8 bytes.
 #[cfg_attr(not(feature = "no-inline"), inline)]


### PR DESCRIPTION
This pull request fixes typos in explanation comments of source files. I kindly request the repository maintainers to review and merge it. Thanks! :heart: 