### PR TITLE
Update README.md - fix grammatrical errors in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ That said the serde support is contained in the `serde_impl` feature which is pa
 
 ### `known-key`
 
-The `known-key` feature changes the hash mechanism for the DOM representation of the underlying JSON object, from `ahash` to `fxhash`. The `ahash` hasher is faster at hashing and provides protection against DOS attacks by forcing multiple keys into a single hashing bucket. The `fxhash` hasher on the other hand allows for repeatable hashing results, which in turn allows memoizing hashes for well known keys and saving time on lookups. In workloads that are heavy at accessing some well known keys this can be a performance advantage.
+The `known-key` feature changes the hash mechanism for the DOM representation of the underlying JSON object, from `ahash` to `fxhash`. The `ahash` hasher is faster at hashing and provides protection against DOS attacks by forcing multiple keys into a single hashing bucket. The `fxhash` hasher on the other hand allows for repeatable hashing results, which in turn allows memoizing hashes for well known keys and saving time on lookups. In workloads that are heavy at accessing some well known keys, this can be a performance advantage.
 
 The `known-key` feature is optional and disabled by default and should be explicitly configured.
 


### PR DESCRIPTION
I have noticed one grammatical mistake in **README** inside section "**known key**"

"**known keys this can be a performance**"  should be "**known keys, this can be a performance**"


Screenshot-

![Screenshot (115)](https://github.com/simd-lite/simd-json/assets/115995339/504aa2ae-98e1-4226-b7cc-f9066895a31b)
