### PR TITLE
Better stable branch hints

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1209,21 +1209,45 @@ macro_rules! unlikely {
 }
 
 /// possible compiler hint that a branch is likely
+///
+/// Technique borrowed from here: <https://github.com/rust-lang/hashbrown/pull/209>
 #[cfg(not(feature = "hints"))]
 #[macro_export]
 macro_rules! likely {
-    ($e:expr) => {
-        $e
-    };
+    ($e:expr) => {{
+        #[inline]
+        #[cold]
+        fn cold() {}
+
+        let cond = $e;
+
+        if !cond {
+            cold();
+        }
+
+        cond
+    }};
 }
 
 /// possible compiler hint that a branch is unlikely
+///
+/// Technique borrowed from here: <https://github.com/rust-lang/hashbrown/pull/209>
 #[cfg(not(feature = "hints"))]
 #[macro_export]
 macro_rules! unlikely {
-    ($e:expr) => {
-        $e
-    };
+    ($e:expr) => {{
+        #[inline]
+        #[cold]
+        fn cold() {}
+
+        let cond = $e;
+
+        if cond {
+            cold();
+        }
+
+        cond
+    }};
 }
 
 /// static cast to an i8


### PR DESCRIPTION
(This is a relatively small change, hence no prior discussion in an issue)

This PR adapts the technique [outlined in `hashbrown`](https://github.com/rust-lang/hashbrown/pull/209) for branch hints on stable, utilizing the `#[cold]` attribute.  
In my local benchmarks I observed an improvement of ~8-13% on average (but I'm not quite sure how many of these were flukes).