### PR TITLE
Treat big ints as floats via feature flag "big-int-as-float"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ bench-canada = []
 bench-citm_catalog = []
 bench-log = []
 bench-twitter = []
+big-int-as-float = []
 
 [[example]]
 name = "perf"

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ The `known-key` feature is optional and disabled by default and should be explic
 
 The `value-no-dup-keys` feature flag toggles stricter behavior for objects when deserializing into a `Value`. When enabled, the Value deserializer will remove duplicate keys in a JSON object and only keep the last one. If not set duplicate keys are considered undefined behavior and Value will not make guarantees on it's behavior.
 
+### `big-int-as-float`
+
+The `big-int-as-float` feature flag treats very large integers that won't fit into u64 as f64 floats. This prevents parsing errors if the JSON you are parsing contains very large numbers. Keep in mind that f64 loses some precision when representing very large numbers.
+
 ## safety
 
 `simd-json` uses **a lot** of unsafe code.

--- a/src/numberparse/correct.rs
+++ b/src/numberparse/correct.rs
@@ -247,7 +247,7 @@ fn parse_large_integer(
     start_idx: usize,
     buf: &[u8],
     negative: bool,
-    end_index: usize,
+    #[allow(unused_variables)] end_index: usize,
 ) -> Result<StaticNode> {
     let mut idx = start_idx;
     if negative {

--- a/tests/jsonchecker.rs
+++ b/tests/jsonchecker.rs
@@ -145,6 +145,7 @@ fail!(fail67);
 fail!(fail68);
 // This is not a failure on 128bit parsing
 #[cfg(not(feature = "128bit"))]
+#[cfg(not(feature = "big-int-as-float"))]
 fail!(fail69);
 
 fail!(fail70);


### PR DESCRIPTION
Currently simd-json errors when a to large integer overflows while parsing.

This PR adds a feature flag `big-int-as-float` that handles cases when int overflows and interprets that as a float instead.
The downside is that you loose some precision but that's ok if you opt into it and how it currently works in most JavaScript based engines.

For example:
`JSON.parse("999999999999999999999999999999")` in Chrome (v8) returns 1e+30
