### PR TITLE
Fix compatibility on unsupported CPU architectures

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -482,7 +482,10 @@ impl<'de> Deserializer<'de> {
         }
     }
     #[cfg(not(any(
-        feature = "runtime-detection",
+        all(
+            feature = "runtime-detection",
+            any(target_arch = "x86_64", target_arch = "x86")
+        ),
         feature = "portable",
         target_feature = "avx2",
         target_feature = "sse4.2",
@@ -594,7 +597,10 @@ impl<'de> Deserializer<'de> {
     }
     #[cfg_attr(not(feature = "no-inline"), inline)]
     #[cfg(not(any(
-        feature = "runtime-detection",
+        all(
+            feature = "runtime-detection",
+            any(target_arch = "x86_64", target_arch = "x86")
+        ),
         feature = "portable",
         target_feature = "avx2",
         target_feature = "sse4.2",
@@ -730,7 +736,10 @@ impl<'de> Deserializer<'de> {
     }
 
     #[cfg(not(any(
-        feature = "runtime-detection",
+        all(
+            feature = "runtime-detection",
+            any(target_arch = "x86_64", target_arch = "x86")
+        ),
         feature = "portable",
         target_feature = "avx2",
         target_feature = "sse4.2",

--- a/src/numberparse.rs
+++ b/src/numberparse.rs
@@ -110,7 +110,7 @@ fn parse_eight_digits_unrolled(chars: &[u8]) -> u32 {
 
 #[cfg_attr(not(feature = "no-inline"), inline)]
 #[cfg(all(
-    any(target_feature = "neon", target_feature = "simd128"),
+    not(any(target_arch = "x86", target_arch = "x86_64")),
     feature = "swar-number-parsing"
 ))]
 #[allow(clippy::cast_ptr_alignment)]

--- a/src/stringparse.rs
+++ b/src/stringparse.rs
@@ -28,6 +28,7 @@ const LOW_SURROGATES: Range<u32> = 0xdc00..0xe000;
 /// handle a unicode codepoint
 /// write appropriate values into dest
 #[cfg_attr(not(feature = "no-inline"), inline)]
+#[allow(dead_code)]
 pub(crate) fn handle_unicode_codepoint(
     src_ptr: &[u8],
     dst_ptr: &mut [u8],


### PR DESCRIPTION
This pull request fixes the issue where the `simd-json` fallback code path isn't working for unsupported CPU architectures.

`#[allow(dead_code)]` is added for the `handle_unicode_codepoint` function since this function is not used when building the fallback logic.

An alternative method would be changing the `Cargo.toml` file to gate `runtime-detection` feature behind `x86_64` and `x86` architectures.