### PR TITLE
Expose the fields of `Error` as public

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -92,7 +92,7 @@ pub enum ErrorType {
     Io(std::io::Error),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum InternalError {
     TapeError,
 }
@@ -155,11 +155,11 @@ impl PartialEq for ErrorType {
 #[derive(Debug, PartialEq)]
 pub struct Error {
     /// Byte index it was encountered at
-    pub index: usize,
+    index: usize,
     /// Current character
-    pub character: Option<char>,
+    character: Option<char>,
     /// Type of error
-    pub error: ErrorType,
+    error: ErrorType,
 }
 
 impl Error {
@@ -182,6 +182,21 @@ impl Error {
             character: None,
             error: t,
         }
+    }
+
+    /// Returns the byte index the error occurred at.
+    pub fn index(&self) -> usize {
+        self.index
+    }
+
+    /// Returns the current character the error occurred at.
+    pub fn character(&self) -> Option<char> {
+        self.character
+    }
+
+    /// Returns the type of error that occurred.
+    pub fn error(&self) -> &ErrorType {
+        &self.error
     }
 }
 impl std::error::Error for Error {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -155,11 +155,11 @@ impl PartialEq for ErrorType {
 #[derive(Debug, PartialEq)]
 pub struct Error {
     /// Byte index it was encountered at
-    index: usize,
+    pub index: usize,
     /// Current character
-    character: Option<char>,
+    pub character: Option<char>,
     /// Type of error
-    error: ErrorType,
+    pub error: ErrorType,
 }
 
 impl Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -185,16 +185,19 @@ impl Error {
     }
 
     /// Returns the byte index the error occurred at.
+    #[must_use]
     pub fn index(&self) -> usize {
         self.index
     }
 
     /// Returns the current character the error occurred at.
+    #[must_use]
     pub fn character(&self) -> Option<char> {
         self.character
     }
 
     /// Returns the type of error that occurred.
+    #[must_use]
     pub fn error(&self) -> &ErrorType {
         &self.error
     }


### PR DESCRIPTION
These fields can be useful when trying to inspect the error.