### PR TITLE
Fix x86 compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,3 +146,11 @@ codegen-units = 1
 lto = true
 opt-level = 3
 panic = "abort"
+
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = [
+    # Legacy code
+    'cfg(portable)',
+    # Tool specific configurations
+    'cfg(tarpaulin_include)',
+] }

--- a/src/impls/avx2/deser.rs
+++ b/src/impls/avx2/deser.rs
@@ -1,10 +1,10 @@
 #[cfg(target_arch = "x86")]
-use std::arch::x86::{
-    __m256i, _mm256_cmpeq_epi8, _mm256_loadu_si256, _mm256_movemask_epi8, _mm256_set1_epi8,
-    _mm256_storeu_si256,
-};
+use std::arch::x86 as arch;
+
 #[cfg(target_arch = "x86_64")]
-use std::arch::x86_64::{
+use std::arch::x86_64 as arch;
+
+use arch::{
     __m256i, _mm256_cmpeq_epi8, _mm256_loadu_si256, _mm256_movemask_epi8, _mm256_set1_epi8,
     _mm256_storeu_si256,
 };
@@ -46,8 +46,7 @@ pub(crate) unsafe fn parse_str<'invoke, 'de>(
     loop {
         // _mm256_loadu_si256 does not require alignment
         #[allow(clippy::cast_ptr_alignment)]
-        let v: __m256i =
-            _mm256_loadu_si256(src.as_ptr().add(src_i).cast::<std::arch::x86_64::__m256i>());
+        let v: __m256i = _mm256_loadu_si256(src.as_ptr().add(src_i).cast::<__m256i>());
 
         // store to dest unconditionally - we can overwrite the bits we don't like
         // later
@@ -97,18 +96,11 @@ pub(crate) unsafe fn parse_str<'invoke, 'de>(
     loop {
         // _mm256_loadu_si256 does not require alignment
         #[allow(clippy::cast_ptr_alignment)]
-        let v: __m256i =
-            _mm256_loadu_si256(src.as_ptr().add(src_i).cast::<std::arch::x86_64::__m256i>());
+        let v: __m256i = _mm256_loadu_si256(src.as_ptr().add(src_i).cast::<__m256i>());
 
         // _mm256_storeu_si256 does not require alignment
         #[allow(clippy::cast_ptr_alignment)]
-        _mm256_storeu_si256(
-            buffer
-                .as_mut_ptr()
-                .add(dst_i)
-                .cast::<std::arch::x86_64::__m256i>(),
-            v,
-        );
+        _mm256_storeu_si256(buffer.as_mut_ptr().add(dst_i).cast::<__m256i>(), v);
 
         // store to dest unconditionally - we can overwrite the bits we don't like
         // later

--- a/src/impls/avx2/stage1.rs
+++ b/src/impls/avx2/stage1.rs
@@ -1,14 +1,12 @@
 #![allow(dead_code)]
 use crate::{static_cast_i32, static_cast_i64, static_cast_u32, Stage1Parse};
 #[cfg(target_arch = "x86")]
-use std::arch::x86::{
-    __m256i, _mm256_add_epi32, _mm256_and_si256, _mm256_cmpeq_epi8, _mm256_loadu_si256,
-    _mm256_max_epu8, _mm256_movemask_epi8, _mm256_set1_epi8, _mm256_set_epi32, _mm256_setr_epi8,
-    _mm256_setzero_si256, _mm256_shuffle_epi8, _mm256_srli_epi32, _mm256_storeu_si256,
-    _mm_clmulepi64_si128, _mm_cvtsi128_si64, _mm_set1_epi8, _mm_set_epi64x,
-};
+use std::arch::x86 as arch;
+
 #[cfg(target_arch = "x86_64")]
-use std::arch::x86_64::{
+use std::arch::x86_64 as arch;
+
+use arch::{
     __m256i, _mm256_add_epi32, _mm256_and_si256, _mm256_cmpeq_epi8, _mm256_loadu_si256,
     _mm256_max_epu8, _mm256_movemask_epi8, _mm256_set1_epi8, _mm256_set_epi32, _mm256_setr_epi8,
     _mm256_setzero_si256, _mm256_shuffle_epi8, _mm256_srli_epi32, _mm256_storeu_si256,
@@ -215,12 +213,7 @@ impl Stage1Parse for SimdInput {
 
             let v: __m256i = _mm256_set_epi32(v7, v6, v5, v4, v3, v2, v1, v0);
             let v: __m256i = _mm256_add_epi32(idx_64_v, v);
-            _mm256_storeu_si256(
-                base.as_mut_ptr()
-                    .add(l)
-                    .cast::<std::arch::x86_64::__m256i>(),
-                v,
-            );
+            _mm256_storeu_si256(base.as_mut_ptr().add(l).cast::<__m256i>(), v);
             l += 8;
         }
         // We have written all the data

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -863,7 +863,7 @@ impl<'de> Deserializer<'de> {
         let len = input.len();
         let simd_safe_len = len + SIMDINPUT_LENGTH;
 
-        if len > std::u32::MAX as usize {
+        if len > u32::MAX as usize {
             return Err(Self::error(ErrorType::InputTooLarge));
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -435,7 +435,7 @@ type FindStructuralBitsFn = unsafe fn(
 pub enum Implementation {
     /// Rust native implementation
     Native,
-    /// Rust native implementation with using std::simd
+    /// Rust native implementation with using [`std::simd`]
     StdSimd,
     /// SSE4.2 implementation
     SSE42,

--- a/src/serde/se.rs
+++ b/src/serde/se.rs
@@ -76,9 +76,9 @@ where
     type Ok = ();
     type Error = Error;
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         let SerializeSeq {
             ref mut s,
@@ -109,9 +109,9 @@ where
     type Ok = ();
     type Error = Error;
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         let SerializeSeq {
             ref mut s,
@@ -141,9 +141,9 @@ where
     type Ok = ();
     type Error = Error;
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         let SerializeSeq {
             ref mut s,
@@ -173,9 +173,9 @@ where
     type Ok = ();
     type Error = Error;
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         let SerializeSeq {
             ref mut s,
@@ -211,9 +211,9 @@ where
     type Ok = ();
     type Error = Error;
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
+    fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         let SerializeMap {
             ref mut s,
@@ -232,9 +232,9 @@ where
         }
     }
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         let SerializeMap { ref mut s, .. } = *self;
         value.serialize(&mut **s)
@@ -399,9 +399,9 @@ where
         Err(key_must_be_a_string())
     }
 
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         Err(key_must_be_a_string())
     }
@@ -414,7 +414,7 @@ where
         Err(key_must_be_a_string())
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -422,7 +422,7 @@ where
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         Err(key_must_be_a_string())
     }
@@ -483,13 +483,9 @@ where
     type Ok = ();
     type Error = Error;
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_field<T: ?Sized>(
-        &mut self,
-        key: &'static str,
-        value: &T,
-    ) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         let SerializeMap {
             ref mut s,
@@ -530,13 +526,9 @@ where
     type Ok = ();
     type Error = Error;
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_field<T: ?Sized>(
-        &mut self,
-        key: &'static str,
-        value: &T,
-    ) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         let SerializeStructVariant {
             ref mut s,
@@ -668,9 +660,9 @@ where
         self.serialize_unit()
     }
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         value.serialize(self)
     }
@@ -693,19 +685,19 @@ where
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_newtype_struct<T: ?Sized>(
+    fn serialize_newtype_struct<T>(
         self,
         _name: &'static str,
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         value.serialize(self)
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -713,7 +705,7 @@ where
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         iomap!(self
             .write(b"{")

--- a/src/serde/se/pp.rs
+++ b/src/serde/se/pp.rs
@@ -113,9 +113,9 @@ where
     type Ok = ();
     type Error = Error;
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         let SerializeSeq {
             ref mut s,
@@ -148,9 +148,9 @@ where
     type Ok = ();
     type Error = Error;
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         let SerializeSeq {
             ref mut s,
@@ -182,9 +182,9 @@ where
     type Ok = ();
     type Error = Error;
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         let SerializeSeq {
             ref mut s,
@@ -216,9 +216,9 @@ where
     type Ok = ();
     type Error = Error;
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         let SerializeSeq {
             ref mut s,
@@ -389,9 +389,9 @@ where
         Err(key_must_be_a_string())
     }
 
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         Err(key_must_be_a_string())
     }
@@ -404,7 +404,7 @@ where
         Err(key_must_be_a_string())
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -412,7 +412,7 @@ where
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         Err(key_must_be_a_string())
     }
@@ -478,9 +478,9 @@ where
     type Ok = ();
     type Error = Error;
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
+    fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         let SerializeMap {
             ref mut s,
@@ -500,9 +500,9 @@ where
         }
     }
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         let SerializeMap { ref mut s, .. } = *self;
         value.serialize(&mut **s)
@@ -525,13 +525,9 @@ where
     type Ok = ();
     type Error = Error;
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_field<T: ?Sized>(
-        &mut self,
-        key: &'static str,
-        value: &T,
-    ) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         let SerializeMap {
             ref mut s,
@@ -576,13 +572,9 @@ where
     type Ok = ();
     type Error = Error;
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_field<T: ?Sized>(
-        &mut self,
-        key: &'static str,
-        value: &T,
-    ) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         let SerializeStructVariant {
             ref mut s,
@@ -725,9 +717,9 @@ where
         self.serialize_unit()
     }
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         value.serialize(self)
     }
@@ -750,19 +742,19 @@ where
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_newtype_struct<T: ?Sized>(
+    fn serialize_newtype_struct<T>(
         self,
         _name: &'static str,
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         value.serialize(self)
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -770,7 +762,7 @@ where
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: serde_ext::Serialize,
+        T: ?Sized + serde_ext::Serialize,
     {
         iomap!(self
             .write(b"{")

--- a/src/serde/value/borrowed/de.rs
+++ b/src/serde/value/borrowed/de.rs
@@ -825,7 +825,7 @@ mod test {
 
     #[test]
     fn option_field_absent_owned() {
-        #[derive(serde::Deserialize, Debug)]
+        #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
         pub struct Person {
             pub name: String,
             pub middle_name: Option<String>,
@@ -835,16 +835,23 @@ mod test {
         let result: Result<Person, _> =
             crate::to_borrowed_value(unsafe { raw_json.as_bytes_mut() })
                 .and_then(super::super::from_value);
-        assert!(result.is_ok());
+        assert_eq!(
+            result,
+            Ok(Person {
+                name: "bob".to_string(),
+                middle_name: None,
+                friends: vec![]
+            })
+        );
     }
     #[test]
     fn option_field_present_owned() {
-        #[derive(serde::Deserialize, Debug)]
+        #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
         pub struct Point {
             pub x: u64,
             pub y: u64,
         }
-        #[derive(serde::Deserialize, Debug)]
+        #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
         pub struct Person {
             pub name: String,
             pub middle_name: Option<String>,
@@ -857,7 +864,15 @@ mod test {
         let result: Result<Person, _> =
             crate::to_borrowed_value(unsafe { raw_json.as_bytes_mut() })
                 .and_then(super::super::from_value);
-        assert!(result.is_ok());
+        assert_eq!(
+            result,
+            Ok(Person {
+                name: "bob".to_string(),
+                middle_name: Some("frank".to_string()),
+                friends: vec![],
+                pos: Point { x: 0, y: 1 },
+            })
+        );
     }
 
     #[test]

--- a/src/serde/value/borrowed/se.rs
+++ b/src/serde/value/borrowed/se.rs
@@ -174,18 +174,14 @@ impl<'se> serde::Serializer for Serializer<'se> {
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_newtype_struct<T: ?Sized>(
-        self,
-        _name: &'static str,
-        value: &T,
-    ) -> Result<Value<'se>>
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<Value<'se>>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         value.serialize(self)
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -193,7 +189,7 @@ impl<'se> serde::Serializer for Serializer<'se> {
         value: &T,
     ) -> Result<Value<'se>>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         let mut values = Object::with_capacity_and_hasher(1, ObjectHasher::default());
         let x = stry!(to_value(value));
@@ -207,9 +203,9 @@ impl<'se> serde::Serializer for Serializer<'se> {
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Value<'se>>
+    fn serialize_some<T>(self, value: &T) -> Result<Value<'se>>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         value.serialize(self)
     }
@@ -293,9 +289,9 @@ impl<'se> serde::ser::SerializeSeq for SerializeVec<'se> {
     type Ok = Value<'se>;
     type Error = Error;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         self.vec.push(stry!(to_value(value)));
         Ok(())
@@ -310,9 +306,9 @@ impl<'se> serde::ser::SerializeTuple for SerializeVec<'se> {
     type Ok = Value<'se>;
     type Error = Error;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         serde::ser::SerializeSeq::serialize_element(self, value)
     }
@@ -326,9 +322,9 @@ impl<'se> serde::ser::SerializeTupleStruct for SerializeVec<'se> {
     type Ok = Value<'se>;
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         serde::ser::SerializeSeq::serialize_element(self, value)
     }
@@ -342,9 +338,9 @@ impl<'se> serde::ser::SerializeTupleVariant for SerializeTupleVariant<'se> {
     type Ok = Value<'se>;
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         self.vec.push(stry!(to_value(value)));
         Ok(())
@@ -362,9 +358,9 @@ impl<'se> serde::ser::SerializeMap for SerializeMap<'se> {
     type Ok = Value<'se>;
     type Error = Error;
 
-    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<()>
+    fn serialize_key<T>(&mut self, key: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         self.next_key = Some(stry!(key.serialize(MapKeySerializer {
             marker: PhantomData
@@ -372,9 +368,9 @@ impl<'se> serde::ser::SerializeMap for SerializeMap<'se> {
         Ok(())
     }
 
-    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_value<T>(&mut self, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         let key = self.next_key.take();
         // Panic because this indicates a bug in the program rather than an
@@ -420,9 +416,9 @@ impl<'se> serde_ext::Serializer for MapKeySerializer<'se> {
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, value: &T) -> Result<Self::Ok>
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<Self::Ok>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         value.serialize(self)
     }
@@ -497,7 +493,7 @@ impl<'se> serde_ext::Serializer for MapKeySerializer<'se> {
         Err(key_must_be_a_string())
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -505,7 +501,7 @@ impl<'se> serde_ext::Serializer for MapKeySerializer<'se> {
         _value: &T,
     ) -> Result<Self::Ok>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(key_must_be_a_string())
     }
@@ -514,9 +510,9 @@ impl<'se> serde_ext::Serializer for MapKeySerializer<'se> {
         Err(key_must_be_a_string())
     }
 
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok>
+    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(key_must_be_a_string())
     }
@@ -570,9 +566,9 @@ impl<'se> serde::ser::SerializeStruct for SerializeMap<'se> {
     type Ok = Value<'se>;
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         stry!(serde::ser::SerializeMap::serialize_key(self, key));
         serde::ser::SerializeMap::serialize_value(self, value)
@@ -587,9 +583,9 @@ impl<'se> serde::ser::SerializeStructVariant for SerializeStructVariant<'se> {
     type Ok = Value<'se>;
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         self.map.insert(key.into(), stry!(to_value(value)));
         Ok(())

--- a/src/serde/value/owned/de.rs
+++ b/src/serde/value/owned/de.rs
@@ -801,7 +801,7 @@ mod test {
 
     #[test]
     fn option_field_absent_owned() {
-        #[derive(serde::Deserialize, Debug)]
+        #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
         pub struct Person {
             pub name: String,
             pub middle_name: Option<String>,
@@ -810,16 +810,23 @@ mod test {
         let mut raw_json = r#"{"name":"bob","friends":[]}"#.to_string();
         let result: Result<Person, _> = crate::to_owned_value(unsafe { raw_json.as_bytes_mut() })
             .and_then(super::super::from_value);
-        assert!(result.is_ok());
+        assert_eq!(
+            result,
+            Ok(Person {
+                name: "bob".to_string(),
+                middle_name: None,
+                friends: vec![]
+            })
+        );
     }
     #[test]
     fn option_field_present_owned() {
-        #[derive(serde::Deserialize, Debug)]
+        #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
         pub struct Point {
             pub x: u64,
             pub y: u64,
         }
-        #[derive(serde::Deserialize, Debug)]
+        #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
         pub struct Person {
             pub name: String,
             pub middle_name: Option<String>,
@@ -830,7 +837,15 @@ mod test {
             r#"{"name":"bob","middle_name": "frank", "friends":[], "pos": [1,2]}"#.to_string();
         let result: Result<Person, _> = crate::to_owned_value(unsafe { raw_json.as_bytes_mut() })
             .and_then(super::super::from_value);
-        assert!(result.is_ok());
+        assert_eq!(
+            result,
+            Ok(Person {
+                name: "bob".to_string(),
+                middle_name: Some("frank".to_string()),
+                friends: vec![],
+                pos: Point { x: 1, y: 2 }
+            })
+        );
     }
 
     #[test]

--- a/src/serde/value/owned/se.rs
+++ b/src/serde/value/owned/se.rs
@@ -161,14 +161,14 @@ impl serde::Serializer for Serializer {
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, value: &T) -> Result<Value>
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<Value>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         value.serialize(self)
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -176,7 +176,7 @@ impl serde::Serializer for Serializer {
         value: &T,
     ) -> Result<Value>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         let mut values = Object::with_capacity_and_hasher(1, ObjectHasher::default());
         values.insert_nocheck(variant.into(), stry!(to_value(value)));
@@ -189,9 +189,9 @@ impl serde::Serializer for Serializer {
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Value>
+    fn serialize_some<T>(self, value: &T) -> Result<Value>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         value.serialize(self)
     }
@@ -275,9 +275,9 @@ impl serde::ser::SerializeSeq for SerializeVec {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         self.vec.push(stry!(to_value(value)));
         Ok(())
@@ -292,9 +292,9 @@ impl serde::ser::SerializeTuple for SerializeVec {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         serde::ser::SerializeSeq::serialize_element(self, value)
     }
@@ -308,9 +308,9 @@ impl serde::ser::SerializeTupleStruct for SerializeVec {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         serde::ser::SerializeSeq::serialize_element(self, value)
     }
@@ -324,9 +324,9 @@ impl serde::ser::SerializeTupleVariant for SerializeTupleVariant {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         self.vec.push(stry!(to_value(value)));
         Ok(())
@@ -343,17 +343,17 @@ impl serde::ser::SerializeMap for SerializeMap {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<()>
+    fn serialize_key<T>(&mut self, key: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         self.next_key = Some(stry!(key.serialize(MapKeySerializer {})));
         Ok(())
     }
 
-    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_value<T>(&mut self, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         let key = self.next_key.take();
         // Panic because this indicates a bug in the program rather than an
@@ -397,9 +397,9 @@ impl serde_ext::Serializer for MapKeySerializer {
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
-    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, value: &T) -> Result<Self::Ok>
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<Self::Ok>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         value.serialize(self)
     }
@@ -473,7 +473,7 @@ impl serde_ext::Serializer for MapKeySerializer {
         Err(key_must_be_a_string())
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -481,7 +481,7 @@ impl serde_ext::Serializer for MapKeySerializer {
         _value: &T,
     ) -> Result<Self::Ok>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(key_must_be_a_string())
     }
@@ -490,9 +490,9 @@ impl serde_ext::Serializer for MapKeySerializer {
         Err(key_must_be_a_string())
     }
 
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok>
+    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(key_must_be_a_string())
     }
@@ -546,9 +546,9 @@ impl serde::ser::SerializeStruct for SerializeMap {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         stry!(serde::ser::SerializeMap::serialize_key(self, key));
         serde::ser::SerializeMap::serialize_value(self, value)
@@ -563,9 +563,9 @@ impl serde::ser::SerializeStructVariant for SerializeStructVariant {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         self.map.insert(key.into(), stry!(to_value(value)));
         Ok(())

--- a/src/value/tape/cmp.rs
+++ b/src/value/tape/cmp.rs
@@ -9,7 +9,7 @@ impl<'tape, 'input> PartialEq for Value<'tape, 'input> {
     #[cfg_attr(not(feature = "no-inline"), inline)]
     #[must_use]
     fn eq(&self, other: &Self) -> bool {
-        self == other
+        self.0 == other.0
     }
 }
 


### PR DESCRIPTION
Compiling for the `i686-unknown-linux-gnu` target leads to multiple compilation failures.

The first set was easy to solve (akin to #246). The second issue is that `std::arch::x86_64::_mm_cvtsi128_si64` does not seem to have an equivalent for `std::arch::x86`. I think this is an oversight in `std::arch::x86`?

I am not confident enough in my SIMD knowledge to create a clever workaround, so I copied the "native rust implementation" for `x86`. If there is some workaround without using `_mm_cvtsi128_si64`, then feel free to change it.

> [!NOTE]
> I do not have a `x86` system myself, so I could not test the changes locally. I only checked by running `cargo build --target i686-unknown-linux-gnu`