### PR TITLE
Add doc(inline) on glob reexport

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ use std::{alloc::dealloc, mem};
 pub use value_trait::StaticNode;
 
 pub use crate::error::{Error, ErrorType};
+#[doc(inline)]
 pub use crate::value::*;
 pub use value_trait::ValueType;
 


### PR DESCRIPTION
I was trying to find `simd_json::to_borrowed_value()` and got pretty lost, because it's not there on the front page of the docs, and searching for it first turns up `simd_json::serde::to_borrowed_value()`, which isn't the same thing.

Using `doc(inline)` makes it show up with its correct name in the crate root docs:

![image](https://github.com/user-attachments/assets/ba041148-b370-4b41-99af-a8f1e5dad08c)


Current:

![image](https://github.com/user-attachments/assets/cb377f3d-13bb-4001-805c-4da0eb90e594)
