### PR TITLE
Feature/ordered float

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ name = "to_tape"
 harness = false
 
 [features]
-default = ["swar-number-parsing", "serde_impl", "runtime-detection", "ordered-float"]
+default = ["swar-number-parsing", "serde_impl", "runtime-detection"]
 
 arraybackend = ["halfbrown/arraybackend"]
 
@@ -155,7 +155,3 @@ unexpected_cfgs = { level = "allow", check-cfg = [
     # Tool specific configurations
     'cfg(tarpaulin_include)',
 ] }
-
-
-[patch.crates-io]
-value-trait = { path = '/home/jbartle9/Development/git/repositories/personal/value-trait' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,3 +155,7 @@ unexpected_cfgs = { level = "allow", check-cfg = [
     # Tool specific configurations
     'cfg(tarpaulin_include)',
 ] }
+
+
+[patch.crates-io]
+value-trait = { git = 'https://github.com/bassmanitram/value-trait', branch = "feature/ordered-float" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ simdutf8 = { version = "0.1.4", features = ["public_imp", "aarch64_neon"] }
 
 beef = { version = "0.5", optional = true }
 halfbrown = "0.2"
-value-trait = { version = "0.10.0" }
+value-trait = { version = "0.10" }
 # ahash known key
 once_cell = { version = "1.17", optional = true }
 ahash = { version = "0.8", optional = true }
@@ -155,7 +155,3 @@ unexpected_cfgs = { level = "allow", check-cfg = [
     # Tool specific configurations
     'cfg(tarpaulin_include)',
 ] }
-
-
-[patch.crates-io]
-value-trait = { git = 'https://github.com/simd-lite/value-trait', branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,4 +158,4 @@ unexpected_cfgs = { level = "allow", check-cfg = [
 
 
 [patch.crates-io]
-value-trait = { git = 'https://github.com/simd-lite/value-trait', branch = "master" }
+value-trait = { git = 'https://github.com/simd-lite/value-trait', branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ name = "to_tape"
 harness = false
 
 [features]
-default = ["swar-number-parsing", "serde_impl", "runtime-detection"]
+default = ["swar-number-parsing", "serde_impl", "runtime-detection", "ordered-float"]
 
 arraybackend = ["halfbrown/arraybackend"]
 
@@ -155,3 +155,7 @@ unexpected_cfgs = { level = "allow", check-cfg = [
     # Tool specific configurations
     'cfg(tarpaulin_include)',
 ] }
+
+
+[patch.crates-io]
+value-trait = { path = '/home/jbartle9/Development/git/repositories/personal/value-trait' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,9 @@ no-inline = []
 # also bench serde in the benchmarks
 bench-serde = ["serde_json"]
 
+# use an Eq wrapper for floats
+ordered-float = ["value-trait/ordered-float"]
+
 # use branch hints - requires nightly :(
 hints = [] # requires nightly
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,4 +158,4 @@ unexpected_cfgs = { level = "allow", check-cfg = [
 
 
 [patch.crates-io]
-value-trait = { git = 'https://github.com/bassmanitram/value-trait', branch = "feature/ordered-float" }
+value-trait = { git = 'https://github.com/simd-lite/value-trait', branch = "master" }

--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ Replace [`std::borrow::Cow`](https://doc.rust-lang.org/std/borrow/enum.Cow.html)
 [`beef::lean::Cow`][beef] This feature is disabled by default, because
 it is a breaking change in the API. 
 
+### `ordered-float`
+
+By default the representation of `Floats` used in `borrowed::Value ` and `owned::Value` is simply a value of `f64`. 
+This however has the normally-not-a-big-deal side effect of _not_ having these `Value` types be `std::cmp::Eq`. This does,
+however, introduce some incompatibilities when offering `simd-json` as a quasi-drop-in replacement for `serde-json`.
+
+So, this feature changes the internal representation of `Floats` to be an `f64` _wrapped by [an Eq-compatible adapter](https://docs.rs/ordered-float/latest/ordered_float/)_.
+
+This probably carries with it some small performance trade-offs, hence its enablement by feature rather than by default.
+
 ### `portable`
 
 **Currently disabled**

--- a/src/numberparse/approx.rs
+++ b/src/numberparse/approx.rs
@@ -207,7 +207,7 @@ impl<'de> Deserializer<'de> {
                 ErrorType::InvalidNumber,
             ))
         } else {
-            Ok(StaticNode::F64(if negative { -i } else { i }))
+            Ok(StaticNode::from(if negative { -i } else { i }))
         }
     }
 
@@ -523,7 +523,7 @@ impl<'de> Deserializer<'de> {
             // We want 0.1e1 to be a float.
             //////////
             if i == 0 {
-                StaticNode::F64(0.0)
+                StaticNode::from(0.0)
             } else {
                 if !(-323..=308).contains(&exponent) {
                     return Self::parse_float(idx, buf, negative);
@@ -531,7 +531,7 @@ impl<'de> Deserializer<'de> {
 
                 let mut d1: f64 = i as f64;
                 d1 *= unsafe { POWER_OF_TEN.get_kinda_unchecked((323 + exponent) as usize) };
-                StaticNode::F64(if negative { d1 * -1.0 } else { d1 })
+                StaticNode::from(if negative { d1 * -1.0 } else { d1 })
             }
         } else {
             if unlikely!(byte_count >= 18) {

--- a/src/numberparse/correct.rs
+++ b/src/numberparse/correct.rs
@@ -402,7 +402,7 @@ mod test {
     use crate::value::owned::to_value;
     use crate::value::owned::Value;
     use crate::value::owned::Value::Static;
-    use value_trait::StaticNode::{self,I64,U64};
+    use value_trait::StaticNode::{self, I64, U64};
 
     fn to_value_from_str(buf: &str) -> Result<Value, Error> {
         let mut val = String::from(buf);
@@ -421,7 +421,10 @@ mod test {
             to_value_from_str("-12345678901234.56789012")?,
             Static(StaticNode::from(-12_345_678_901_234.568))
         );
-        assert_eq!(to_value_from_str("0.4e-001")?, Static(StaticNode::from(0.04)));
+        assert_eq!(
+            to_value_from_str("0.4e-001")?,
+            Static(StaticNode::from(0.04))
+        );
         assert_eq!(
             to_value_from_str("0.123456789e-12")?,
             Static(StaticNode::from(1.234_567_89e-13))
@@ -434,9 +437,12 @@ mod test {
         assert_eq!(
             to_value_from_str("0.0000000000000000000000000000000000000000000000000123e50")
                 .expect("1.23"),
-                Static(StaticNode::from(1.23))
+            Static(StaticNode::from(1.23))
         );
-        assert_eq!(to_value_from_str("0.6").expect("0.6"), Static(StaticNode::from(0.6)));
+        assert_eq!(
+            to_value_from_str("0.6").expect("0.6"),
+            Static(StaticNode::from(0.6))
+        );
         Ok(())
     }
 
@@ -536,9 +542,15 @@ mod test {
     #[test]
     fn zero_float() -> Result<(), crate::Error> {
         assert_eq!(to_value_from_str("0e1")?, Static(StaticNode::from(0.0)));
-        assert_eq!(to_value_from_str("0.00e-00")?, Static(StaticNode::from(0.0)));
+        assert_eq!(
+            to_value_from_str("0.00e-00")?,
+            Static(StaticNode::from(0.0))
+        );
         assert_eq!(to_value_from_str("0e-1")?, Static(StaticNode::from(-0.0)));
-        assert_eq!(to_value_from_str("-0.00e-00")?, Static(StaticNode::from(-0.0)));
+        assert_eq!(
+            to_value_from_str("-0.00e-00")?,
+            Static(StaticNode::from(-0.0))
+        );
         Ok(())
     }
 

--- a/src/numberparse/correct.rs
+++ b/src/numberparse/correct.rs
@@ -321,9 +321,9 @@ fn f64_from_parts(
         } else {
             f *= get!(POW10, exponent);
         }
-        Ok(StaticNode::F64(if positive { f } else { -f }))
+        Ok(StaticNode::from(if positive { f } else { -f }))
     } else if significand == 0 {
-        Ok(StaticNode::F64(if positive { 0.0 } else { -0.0 }))
+        Ok(StaticNode::from(if positive { 0.0 } else { -0.0 }))
     } else if (-325..=308).contains(&exponent) {
         let (factor_mantissa, factor_exponent) = get!(POW10_COMPONENTS, exponent + 325);
         let mut leading_zeroes = u64::from(significand.leading_zeros());
@@ -373,7 +373,7 @@ fn f64_from_parts(
         if res.is_infinite() {
             err!(offset, get!(slice, offset))
         }
-        Ok(StaticNode::F64(res))
+        Ok(StaticNode::from(res))
     } else {
         f64_from_parts_slow(slice, offset)
     }
@@ -389,7 +389,7 @@ fn f64_from_parts_slow(slice: &[u8], offset: usize) -> Result<StaticNode> {
                 err!(offset, get!(slice, 0))
             }
 
-            Ok(StaticNode::F64(val))
+            Ok(StaticNode::from(val))
         }
         Err(_) => err!(offset, get!(slice, offset)),
     }
@@ -402,9 +402,7 @@ mod test {
     use crate::value::owned::to_value;
     use crate::value::owned::Value;
     use crate::value::owned::Value::Static;
-    use value_trait::StaticNode::F64;
-    use value_trait::StaticNode::I64;
-    use value_trait::StaticNode::U64;
+    use value_trait::StaticNode::{self,I64,U64};
 
     fn to_value_from_str(buf: &str) -> Result<Value, Error> {
         let mut val = String::from(buf);
@@ -417,28 +415,28 @@ mod test {
     fn float() -> Result<(), crate::Error> {
         assert_eq!(
             to_value_from_str("0.4e5").expect("40000.0"),
-            Static(F64(40000.0))
+            Static(StaticNode::from(40000.0))
         );
         assert_eq!(
             to_value_from_str("-12345678901234.56789012")?,
-            Static(F64(-12_345_678_901_234.568))
+            Static(StaticNode::from(-12_345_678_901_234.568))
         );
-        assert_eq!(to_value_from_str("0.4e-001")?, Static(F64(0.04)));
+        assert_eq!(to_value_from_str("0.4e-001")?, Static(StaticNode::from(0.04)));
         assert_eq!(
             to_value_from_str("0.123456789e-12")?,
-            Static(F64(1.234_567_89e-13))
+            Static(StaticNode::from(1.234_567_89e-13))
         );
         assert_eq!(to_value_from_str("1.234567890E+34")?, 1.234_567_89e34);
         assert_eq!(
             to_value_from_str("23456789012E66")?,
-            Static(F64(2.345_678_901_2e76))
+            Static(StaticNode::from(2.345_678_901_2e76))
         );
         assert_eq!(
             to_value_from_str("0.0000000000000000000000000000000000000000000000000123e50")
                 .expect("1.23"),
-            Static(F64(1.23))
+                Static(StaticNode::from(1.23))
         );
-        assert_eq!(to_value_from_str("0.6").expect("0.6"), Static(F64(0.6)));
+        assert_eq!(to_value_from_str("0.6").expect("0.6"), Static(StaticNode::from(0.6)));
         Ok(())
     }
 
@@ -537,10 +535,10 @@ mod test {
 
     #[test]
     fn zero_float() -> Result<(), crate::Error> {
-        assert_eq!(to_value_from_str("0e1")?, Static(F64(0.0)));
-        assert_eq!(to_value_from_str("0.00e-00")?, Static(F64(0.0)));
-        assert_eq!(to_value_from_str("0e-1")?, Static(F64(-0.0)));
-        assert_eq!(to_value_from_str("-0.00e-00")?, Static(F64(-0.0)));
+        assert_eq!(to_value_from_str("0e1")?, Static(StaticNode::from(0.0)));
+        assert_eq!(to_value_from_str("0.00e-00")?, Static(StaticNode::from(0.0)));
+        assert_eq!(to_value_from_str("0e-1")?, Static(StaticNode::from(-0.0)));
+        assert_eq!(to_value_from_str("-0.00e-00")?, Static(StaticNode::from(-0.0)));
         Ok(())
     }
 
@@ -556,14 +554,14 @@ mod test {
     fn minus_309() -> Result<(), crate::Error> {
         assert_eq!(
             to_value_from_str("-5.96916642387374e-309")?,
-            Static(F64(-5.969_166_423_873_74e-_309))
+            Static(StaticNode::from(-5.969_166_423_873_74e-_309))
         );
         Ok(())
     }
     #[allow(clippy::unreadable_literal)]
     #[test]
     fn tiny_float() -> Result<(), crate::Error> {
-        assert_eq!(to_value_from_str("-0.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000596916642387374")?, Static(F64(-0.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000596916642387374)));
+        assert_eq!(to_value_from_str("-0.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000596916642387374")?, Static(StaticNode::from(-0.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000596916642387374)));
         Ok(())
     }
 
@@ -572,7 +570,7 @@ mod test {
     fn huge_int() -> Result<(), crate::Error> {
         assert_eq!(
             to_value_from_str("999999999999999999999999999999")?,
-            Static(F64(999999999999999999999999999999f64))
+            StaticNode::from(999999999999999999999999999999f64)
         );
         Ok(())
     }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -98,7 +98,7 @@ pub unsafe fn from_str<'a, T>(s: &'a mut str) -> Result<T>
 where
     T: Deserialize<'a>,
 {
-    let mut deserializer = stry!(Deserializer::from_slice(s.as_bytes_mut()));
+    let mut deserializer = stry!(Deserializer::from_slice(unsafe{s.as_bytes_mut()}));
 
     T::deserialize(&mut deserializer)
 }
@@ -126,7 +126,7 @@ where
     T: Deserialize<'a>,
 {
     let mut deserializer = stry!(Deserializer::from_slice_with_buffers(
-        s.as_bytes_mut(),
+        unsafe{s.as_bytes_mut()},
         buffers
     ));
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -323,6 +323,7 @@ impl<'de> Deserializer<'de> {
     #[allow(clippy::cast_possible_wrap, clippy::cast_precision_loss)]
     fn parse_double(&mut self) -> Result<f64> {
         match unsafe { self.next_() } {
+            #[allow(clippy::useless_conversion)] // .into() required by ordered-float
             Node::Static(StaticNode::F64(n)) => Ok(n.into()),
             Node::Static(StaticNode::I64(n)) => Ok(n as f64),
             Node::Static(StaticNode::U64(n)) => Ok(n as f64),
@@ -384,6 +385,7 @@ impl TryInto<serde_json::Value> for OwnedValue {
                     .into(),
             ),
             Self::Static(StaticNode::F64(n)) => {
+                #[allow(clippy::useless_conversion)] // .into() required by ordered-float
                 if let Some(n) = serde_json::Number::from_f64(n.into()) {
                     Value::Number(n)
                 } else {
@@ -450,6 +452,7 @@ impl<'value> TryInto<serde_json::Value> for BorrowedValue<'value> {
                     .into(),
             ),
             BorrowedValue::Static(StaticNode::F64(n)) => {
+                #[allow(clippy::useless_conversion)] // .into() required by ordered-float
                 if let Some(n) = serde_json::Number::from_f64(n.into()) {
                     Value::Number(n)
                 } else {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -98,7 +98,7 @@ pub unsafe fn from_str<'a, T>(s: &'a mut str) -> Result<T>
 where
     T: Deserialize<'a>,
 {
-    let mut deserializer = stry!(Deserializer::from_slice(unsafe{s.as_bytes_mut()}));
+    let mut deserializer = stry!(Deserializer::from_slice(unsafe { s.as_bytes_mut() }));
 
     T::deserialize(&mut deserializer)
 }
@@ -126,7 +126,7 @@ where
     T: Deserialize<'a>,
 {
     let mut deserializer = stry!(Deserializer::from_slice_with_buffers(
-        unsafe{s.as_bytes_mut()},
+        unsafe { s.as_bytes_mut() },
         buffers
     ));
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -323,7 +323,7 @@ impl<'de> Deserializer<'de> {
     #[allow(clippy::cast_possible_wrap, clippy::cast_precision_loss)]
     fn parse_double(&mut self) -> Result<f64> {
         match unsafe { self.next_() } {
-            Node::Static(StaticNode::F64(n)) => Ok(n),
+            Node::Static(StaticNode::F64(n)) => Ok(n.into()),
             Node::Static(StaticNode::I64(n)) => Ok(n as f64),
             Node::Static(StaticNode::U64(n)) => Ok(n as f64),
             _ => Err(Self::error(ErrorType::ExpectedFloat)),
@@ -344,7 +344,7 @@ impl TryFrom<serde_json::Value> for OwnedValue {
                 } else if let Some(n) = b.as_u64() {
                     Self::Static(StaticNode::U64(n))
                 } else if let Some(n) = b.as_f64() {
-                    Self::Static(StaticNode::F64(n))
+                    Self::Static(StaticNode::from(n))
                 } else {
                     return Err(SerdeConversionError::Oops);
                 }
@@ -384,7 +384,7 @@ impl TryInto<serde_json::Value> for OwnedValue {
                     .into(),
             ),
             Self::Static(StaticNode::F64(n)) => {
-                if let Some(n) = serde_json::Number::from_f64(n) {
+                if let Some(n) = serde_json::Number::from_f64(n.into()) {
                     Value::Number(n)
                 } else {
                     return Err(SerdeConversionError::NanOrInfinity);
@@ -450,7 +450,7 @@ impl<'value> TryInto<serde_json::Value> for BorrowedValue<'value> {
                     .into(),
             ),
             BorrowedValue::Static(StaticNode::F64(n)) => {
-                if let Some(n) = serde_json::Number::from_f64(n) {
+                if let Some(n) = serde_json::Number::from_f64(n.into()) {
                     Value::Number(n)
                 } else {
                     return Err(SerdeConversionError::NanOrInfinity);

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -22,7 +22,7 @@ where
             Node::String(s) => visitor.visit_borrowed_str(s),
             Node::Static(StaticNode::Null) => visitor.visit_unit(),
             Node::Static(StaticNode::Bool(b)) => visitor.visit_bool(b),
-            Node::Static(StaticNode::F64(n)) => visitor.visit_f64(n),
+            Node::Static(StaticNode::F64(n)) => visitor.visit_f64(n.into()),
             Node::Static(StaticNode::I64(n)) => visitor.visit_i64(n),
             #[cfg(feature = "128bit")]
             Node::Static(StaticNode::I128(n)) => visitor.visit_i128(n),

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -22,6 +22,7 @@ where
             Node::String(s) => visitor.visit_borrowed_str(s),
             Node::Static(StaticNode::Null) => visitor.visit_unit(),
             Node::Static(StaticNode::Bool(b)) => visitor.visit_bool(b),
+            #[allow(clippy::useless_conversion)] // .into() required by ordered-float
             Node::Static(StaticNode::F64(n)) => visitor.visit_f64(n.into()),
             Node::Static(StaticNode::I64(n)) => visitor.visit_i64(n),
             #[cfg(feature = "128bit")]

--- a/src/serde/value/borrowed/de.rs
+++ b/src/serde/value/borrowed/de.rs
@@ -35,7 +35,7 @@ impl<'de> de::Deserializer<'de> for Value<'de> {
             Value::Static(StaticNode::U64(n)) => visitor.visit_u64(n),
             #[cfg(feature = "128bit")]
             Value::Static(StaticNode::U128(n)) => visitor.visit_u128(n),
-            Value::Static(StaticNode::F64(n)) => visitor.visit_f64(n),
+            Value::Static(StaticNode::F64(n)) => visitor.visit_f64(n.into()),
             #[cfg(feature = "beef")]
             Value::String(s) => {
                 if s.is_borrowed() {
@@ -400,7 +400,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::F64(f64::from(value))))
+        Ok(Value::Static(StaticNode::from(f64::from(value))))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -408,7 +408,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::F64(value)))
+        Ok(Value::Static(StaticNode::from(value)))
     }
 
     /****************** stringy stuff ******************/
@@ -621,7 +621,7 @@ impl<'de> de::Deserializer<'de> for &'de Value<'de> {
             Value::Static(StaticNode::U64(n)) => visitor.visit_u64(*n),
             #[cfg(feature = "128bit")]
             Value::Static(StaticNode::U128(n)) => visitor.visit_u128(*n),
-            Value::Static(StaticNode::F64(n)) => visitor.visit_f64(*n),
+            Value::Static(StaticNode::F64(n)) => visitor.visit_f64((*n).into()),
             Value::String(s) => visitor.visit_borrowed_str(s),
             Value::Array(a) => visitor.visit_seq(ArrayRef(a.as_slice().iter())),
             Value::Object(o) => visitor.visit_map(ObjectRefAccess::new(o.iter())),

--- a/src/serde/value/borrowed/de.rs
+++ b/src/serde/value/borrowed/de.rs
@@ -35,6 +35,7 @@ impl<'de> de::Deserializer<'de> for Value<'de> {
             Value::Static(StaticNode::U64(n)) => visitor.visit_u64(n),
             #[cfg(feature = "128bit")]
             Value::Static(StaticNode::U128(n)) => visitor.visit_u128(n),
+            #[allow(clippy::useless_conversion)] // .into() required by ordered-float
             Value::Static(StaticNode::F64(n)) => visitor.visit_f64(n.into()),
             #[cfg(feature = "beef")]
             Value::String(s) => {
@@ -621,6 +622,7 @@ impl<'de> de::Deserializer<'de> for &'de Value<'de> {
             Value::Static(StaticNode::U64(n)) => visitor.visit_u64(*n),
             #[cfg(feature = "128bit")]
             Value::Static(StaticNode::U128(n)) => visitor.visit_u128(*n),
+            #[allow(clippy::useless_conversion)] // .into() required by ordered-float
             Value::Static(StaticNode::F64(n)) => visitor.visit_f64((*n).into()),
             Value::String(s) => visitor.visit_borrowed_str(s),
             Value::Array(a) => visitor.visit_seq(ArrayRef(a.as_slice().iter())),

--- a/src/serde/value/borrowed/se.rs
+++ b/src/serde/value/borrowed/se.rs
@@ -21,6 +21,7 @@ impl<'value> Serialize for Value<'value> {
         match self {
             Value::Static(StaticNode::Null) => serializer.serialize_unit(),
             Value::Static(StaticNode::Bool(b)) => serializer.serialize_bool(*b),
+            #[allow(clippy::useless_conversion)] // .into() required by ordered-float
             Value::Static(StaticNode::F64(f)) => serializer.serialize_f64((*f).into()),
             Value::Static(StaticNode::U64(i)) => serializer.serialize_u64(*i),
             #[cfg(feature = "128bit")]

--- a/src/serde/value/borrowed/se.rs
+++ b/src/serde/value/borrowed/se.rs
@@ -21,7 +21,7 @@ impl<'value> Serialize for Value<'value> {
         match self {
             Value::Static(StaticNode::Null) => serializer.serialize_unit(),
             Value::Static(StaticNode::Bool(b)) => serializer.serialize_bool(*b),
-            Value::Static(StaticNode::F64(f)) => serializer.serialize_f64(*f),
+            Value::Static(StaticNode::F64(f)) => serializer.serialize_f64((*f).into()),
             Value::Static(StaticNode::U64(i)) => serializer.serialize_u64(*i),
             #[cfg(feature = "128bit")]
             Value::Static(StaticNode::U128(i)) => serializer.serialize_u128(*i),
@@ -133,7 +133,7 @@ impl<'se> serde::Serializer for Serializer<'se> {
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
     fn serialize_f64(self, value: f64) -> Result<Value<'se>> {
-        Ok(Value::Static(StaticNode::F64(value)))
+        Ok(Value::Static(StaticNode::from(value)))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -629,7 +629,7 @@ mod test {
 
     #[test]
     fn float() {
-        let v = Value::Static(StaticNode::F64(1.0));
+        let v = Value::Static(StaticNode::from(1.0));
         let s = serde_json::to_string(&v).expect("Failed to serialize");
         assert_eq!(s, "1.0");
     }

--- a/src/serde/value/owned/de.rs
+++ b/src/serde/value/owned/de.rs
@@ -34,7 +34,7 @@ impl<'de> de::Deserializer<'de> for Value {
             Value::Static(StaticNode::U64(n)) => visitor.visit_u64(n),
             #[cfg(feature = "128bit")]
             Value::Static(StaticNode::U128(n)) => visitor.visit_u128(n),
-            Value::Static(StaticNode::F64(n)) => visitor.visit_f64(n),
+            Value::Static(StaticNode::F64(n)) => visitor.visit_f64(n.into()),
             Value::String(s) => visitor.visit_string(s),
             Value::Array(a) => visitor.visit_seq(Array(a.into_iter())),
             Value::Object(o) => visitor.visit_map(ObjectAccess {
@@ -386,7 +386,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::F64(f64::from(value))))
+        Ok(Value::Static(StaticNode::from(f64::from(value))))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -394,7 +394,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::F64(value)))
+        Ok(Value::Static(StaticNode::from(value)))
     }
 
     /****************** stringy stuff ******************/
@@ -608,7 +608,7 @@ impl<'de> de::Deserializer<'de> for &'de Value {
             Value::Static(StaticNode::U64(n)) => visitor.visit_u64(*n),
             #[cfg(feature = "128bit")]
             Value::Static(StaticNode::U128(n)) => visitor.visit_u128(*n),
-            Value::Static(StaticNode::F64(n)) => visitor.visit_f64(*n),
+            Value::Static(StaticNode::F64(n)) => visitor.visit_f64((*n).into()),
             Value::String(s) => visitor.visit_borrowed_str(s),
             Value::Array(a) => visitor.visit_seq(ArrayRef(a.as_slice().iter())),
             Value::Object(o) => visitor.visit_map(ObjectRefAccess::new(o.iter())),

--- a/src/serde/value/owned/de.rs
+++ b/src/serde/value/owned/de.rs
@@ -34,6 +34,7 @@ impl<'de> de::Deserializer<'de> for Value {
             Value::Static(StaticNode::U64(n)) => visitor.visit_u64(n),
             #[cfg(feature = "128bit")]
             Value::Static(StaticNode::U128(n)) => visitor.visit_u128(n),
+            #[allow(clippy::useless_conversion)] // .into() required by ordered-float
             Value::Static(StaticNode::F64(n)) => visitor.visit_f64(n.into()),
             Value::String(s) => visitor.visit_string(s),
             Value::Array(a) => visitor.visit_seq(Array(a.into_iter())),
@@ -608,6 +609,7 @@ impl<'de> de::Deserializer<'de> for &'de Value {
             Value::Static(StaticNode::U64(n)) => visitor.visit_u64(*n),
             #[cfg(feature = "128bit")]
             Value::Static(StaticNode::U128(n)) => visitor.visit_u128(*n),
+            #[allow(clippy::useless_conversion)] // .into() required by ordered-float
             Value::Static(StaticNode::F64(n)) => visitor.visit_f64((*n).into()),
             Value::String(s) => visitor.visit_borrowed_str(s),
             Value::Array(a) => visitor.visit_seq(ArrayRef(a.as_slice().iter())),

--- a/src/serde/value/owned/se.rs
+++ b/src/serde/value/owned/se.rs
@@ -18,6 +18,7 @@ impl Serialize for Value {
         match self {
             Value::Static(StaticNode::Null) => serializer.serialize_unit(),
             Value::Static(StaticNode::Bool(b)) => serializer.serialize_bool(*b),
+            #[allow(clippy::useless_conversion)] // .into() required by ordered-float
             Value::Static(StaticNode::F64(f)) => serializer.serialize_f64((*f).into()),
             Value::Static(StaticNode::U64(i)) => serializer.serialize_u64(*i),
             #[cfg(feature = "128bit")]

--- a/src/serde/value/owned/se.rs
+++ b/src/serde/value/owned/se.rs
@@ -18,7 +18,7 @@ impl Serialize for Value {
         match self {
             Value::Static(StaticNode::Null) => serializer.serialize_unit(),
             Value::Static(StaticNode::Bool(b)) => serializer.serialize_bool(*b),
-            Value::Static(StaticNode::F64(f)) => serializer.serialize_f64(*f),
+            Value::Static(StaticNode::F64(f)) => serializer.serialize_f64((*f).into()),
             Value::Static(StaticNode::U64(i)) => serializer.serialize_u64(*i),
             #[cfg(feature = "128bit")]
             Value::Static(StaticNode::U128(i)) => serializer.serialize_u128(*i),
@@ -120,7 +120,7 @@ impl serde::Serializer for Serializer {
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
     fn serialize_f64(self, value: f64) -> Result<Value> {
-        Ok(Value::Static(StaticNode::F64(value)))
+        Ok(Value::Static(StaticNode::from(value)))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -954,10 +954,6 @@ mod test {
         assert_eq!(Value::default(), Value::null());
     }
 
-    fn static_node_f64(f: f64) -> StaticNode {
-        StaticNode::from(f)
-    }
-
     #[cfg(not(target_arch = "wasm32"))]
     use proptest::prelude::*;
 
@@ -975,7 +971,7 @@ mod test {
                 .prop_map(StaticNode::U64)
                 .prop_map(Value::Static),
             any::<f64>()
-                .prop_map(static_node_f64)
+                .prop_map(StaticNode::from)
                 .prop_map(Value::Static),
             ".*".prop_map(Value::from),
         ];

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -77,6 +77,7 @@ pub fn to_value_with_buffers<'value>(
 /// Borrowed JSON-DOM Value, consider using the `ValueTrait`
 /// to access its content
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "ordered-float", derive(Eq))]
 pub enum Value<'value> {
     /// Static values
     Static(StaticNode),

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -466,7 +466,7 @@ impl<'tape, 'de> BorrowSliceDeserializer<'tape, 'de> {
     }
     #[cfg_attr(not(feature = "no-inline"), inline)]
     pub unsafe fn next_(&mut self) -> Node<'de> {
-        let r = *self.tape.get_kinda_unchecked(self.idx);
+        let r = unsafe{*self.tape.get_kinda_unchecked(self.idx)};
         self.idx += 1;
         r
     }
@@ -954,6 +954,10 @@ mod test {
         assert_eq!(Value::default(), Value::null());
     }
 
+    fn static_node_f64(f: f64) -> StaticNode {
+        StaticNode::from(f)
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     use proptest::prelude::*;
 
@@ -971,7 +975,7 @@ mod test {
                 .prop_map(StaticNode::U64)
                 .prop_map(Value::Static),
             any::<f64>()
-                .prop_map(StaticNode::F64)
+                .prop_map(static_node_f64)
                 .prop_map(Value::Static),
             ".*".prop_map(Value::from),
         ];

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -467,7 +467,7 @@ impl<'tape, 'de> BorrowSliceDeserializer<'tape, 'de> {
     }
     #[cfg_attr(not(feature = "no-inline"), inline)]
     pub unsafe fn next_(&mut self) -> Node<'de> {
-        let r = unsafe{*self.tape.get_kinda_unchecked(self.idx)};
+        let r = unsafe { *self.tape.get_kinda_unchecked(self.idx) };
         self.idx += 1;
         r
     }

--- a/src/value/borrowed/from.rs
+++ b/src/value/borrowed/from.rs
@@ -191,7 +191,7 @@ impl<'value> From<f32> for Value<'value> {
     #[cfg_attr(not(feature = "no-inline"), inline)]
     #[must_use]
     fn from(f: f32) -> Self {
-        Value::Static(StaticNode::F64(f64::from(f)))
+        Value::Static(StaticNode::from(f64::from(f)))
     }
 }
 
@@ -199,7 +199,7 @@ impl<'value> From<f64> for Value<'value> {
     #[cfg_attr(not(feature = "no-inline"), inline)]
     #[must_use]
     fn from(f: f64) -> Self {
-        Value::Static(StaticNode::F64(f))
+        Value::Static(StaticNode::from(f))
     }
 }
 

--- a/src/value/borrowed/serialize.rs
+++ b/src/value/borrowed/serialize.rs
@@ -95,6 +95,7 @@ trait Generator: BaseGenerator {
             Value::Static(StaticNode::U64(number)) => self.write_int(number),
             #[cfg(feature = "128bit")]
             Value::Static(StaticNode::U128(number)) => self.write_int(number),
+            #[allow(clippy::useless_conversion)] // .into() required by ordered-float
             Value::Static(StaticNode::F64(number)) => self.write_float(number.into()),
             Value::Static(StaticNode::Bool(true)) => self.write(b"true"),
             Value::Static(StaticNode::Bool(false)) => self.write(b"false"),
@@ -175,6 +176,7 @@ trait FastGenerator: BaseGenerator {
             Value::Static(StaticNode::U64(number)) => self.write_int(number),
             #[cfg(feature = "128bit")]
             Value::Static(StaticNode::U128(number)) => self.write_int(number),
+            #[allow(clippy::useless_conversion)] // .into() required by ordered-float
             Value::Static(StaticNode::F64(number)) => self.write_float(number.into()),
             Value::Static(StaticNode::Bool(true)) => self.write(b"true"),
             Value::Static(StaticNode::Bool(false)) => self.write(b"false"),

--- a/src/value/borrowed/serialize.rs
+++ b/src/value/borrowed/serialize.rs
@@ -95,7 +95,7 @@ trait Generator: BaseGenerator {
             Value::Static(StaticNode::U64(number)) => self.write_int(number),
             #[cfg(feature = "128bit")]
             Value::Static(StaticNode::U128(number)) => self.write_int(number),
-            Value::Static(StaticNode::F64(number)) => self.write_float(number),
+            Value::Static(StaticNode::F64(number)) => self.write_float(number.into()),
             Value::Static(StaticNode::Bool(true)) => self.write(b"true"),
             Value::Static(StaticNode::Bool(false)) => self.write(b"false"),
             Value::String(ref string) => self.write_string(string),
@@ -175,7 +175,7 @@ trait FastGenerator: BaseGenerator {
             Value::Static(StaticNode::U64(number)) => self.write_int(number),
             #[cfg(feature = "128bit")]
             Value::Static(StaticNode::U128(number)) => self.write_int(number),
-            Value::Static(StaticNode::F64(number)) => self.write_float(number),
+            Value::Static(StaticNode::F64(number)) => self.write_float(number.into()),
             Value::Static(StaticNode::Bool(true)) => self.write(b"true"),
             Value::Static(StaticNode::Bool(false)) => self.write(b"false"),
             Value::String(ref string) => self.write_string(string),

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -803,6 +803,10 @@ mod test {
         assert_eq!(Value::default(), Value::null());
     }
 
+    fn static_node_f64(f: f64) -> StaticNode {
+        StaticNode::from(f)
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     use proptest::prelude::*;
     #[cfg(not(target_arch = "wasm32"))]
@@ -816,7 +820,7 @@ mod test {
                 .prop_map(StaticNode::I64)
                 .prop_map(Value::Static),
             any::<f64>()
-                .prop_map(StaticNode::F64)
+                .prop_map(static_node_f64)
                 .prop_map(Value::Static),
             ".*".prop_map(Value::from),
         ];

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -74,6 +74,7 @@ pub fn to_value_with_buffers(s: &mut [u8], buffers: &mut Buffers) -> Result<Valu
 /// This is slower then the `BorrowedValue` as a tradeoff
 /// for getting rid of lifetimes.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "ordered-float", derive(Eq))]
 pub enum Value {
     /// Static values
     Static(StaticNode),

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -803,10 +803,6 @@ mod test {
         assert_eq!(Value::default(), Value::null());
     }
 
-    fn static_node_f64(f: f64) -> StaticNode {
-        StaticNode::from(f)
-    }
-
     #[cfg(not(target_arch = "wasm32"))]
     use proptest::prelude::*;
     #[cfg(not(target_arch = "wasm32"))]
@@ -820,7 +816,7 @@ mod test {
                 .prop_map(StaticNode::I64)
                 .prop_map(Value::Static),
             any::<f64>()
-                .prop_map(static_node_f64)
+                .prop_map(StaticNode::from)
                 .prop_map(Value::Static),
             ".*".prop_map(Value::from),
         ];

--- a/src/value/owned/from.rs
+++ b/src/value/owned/from.rs
@@ -190,7 +190,7 @@ impl From<f32> for Value {
     #[cfg_attr(not(feature = "no-inline"), inline)]
     #[must_use]
     fn from(f: f32) -> Self {
-        Self::Static(StaticNode::F64(f64::from(f)))
+        Self::Static(StaticNode::from(f64::from(f)))
     }
 }
 
@@ -198,7 +198,7 @@ impl From<f64> for Value {
     #[cfg_attr(not(feature = "no-inline"), inline)]
     #[must_use]
     fn from(f: f64) -> Self {
-        Self::Static(StaticNode::F64(f))
+        Self::Static(StaticNode::from(f))
     }
 }
 

--- a/src/value/owned/serialize.rs
+++ b/src/value/owned/serialize.rs
@@ -95,6 +95,7 @@ trait Generator: BaseGenerator {
             Value::Static(StaticNode::U64(number)) => self.write_int(number),
             #[cfg(feature = "128bit")]
             Value::Static(StaticNode::U128(number)) => self.write_int(number),
+            #[allow(clippy::useless_conversion)] // .into() required by ordered-float
             Value::Static(StaticNode::F64(number)) => self.write_float(number.into()),
             Value::Static(StaticNode::Bool(true)) => self.write(b"true"),
             Value::Static(StaticNode::Bool(false)) => self.write(b"false"),
@@ -177,6 +178,7 @@ trait FastGenerator: BaseGenerator {
             Value::Static(StaticNode::U64(number)) => self.write_int(number),
             #[cfg(feature = "128bit")]
             Value::Static(StaticNode::U128(number)) => self.write_int(number),
+            #[allow(clippy::useless_conversion)] // .into() required by ordered-float
             Value::Static(StaticNode::F64(number)) => self.write_float(number.into()),
             Value::Static(StaticNode::Bool(true)) => self.write(b"true"),
             Value::Static(StaticNode::Bool(false)) => self.write(b"false"),

--- a/src/value/owned/serialize.rs
+++ b/src/value/owned/serialize.rs
@@ -95,7 +95,7 @@ trait Generator: BaseGenerator {
             Value::Static(StaticNode::U64(number)) => self.write_int(number),
             #[cfg(feature = "128bit")]
             Value::Static(StaticNode::U128(number)) => self.write_int(number),
-            Value::Static(StaticNode::F64(number)) => self.write_float(number),
+            Value::Static(StaticNode::F64(number)) => self.write_float(number.into()),
             Value::Static(StaticNode::Bool(true)) => self.write(b"true"),
             Value::Static(StaticNode::Bool(false)) => self.write(b"false"),
             Value::String(ref string) => self.write_string(string),
@@ -177,7 +177,7 @@ trait FastGenerator: BaseGenerator {
             Value::Static(StaticNode::U64(number)) => self.write_int(number),
             #[cfg(feature = "128bit")]
             Value::Static(StaticNode::U128(number)) => self.write_int(number),
-            Value::Static(StaticNode::F64(number)) => self.write_float(number),
+            Value::Static(StaticNode::F64(number)) => self.write_float(number.into()),
             Value::Static(StaticNode::Bool(true)) => self.write(b"true"),
             Value::Static(StaticNode::Bool(false)) => self.write(b"false"),
             Value::String(ref string) => self.write_string(string),

--- a/src/value/tape/trait_impls.rs
+++ b/src/value/tape/trait_impls.rs
@@ -738,7 +738,7 @@ trait Generator: BaseGenerator {
             Node::Static(StaticNode::U64(number)) => self.write_int(number),
             #[cfg(feature = "128bit")]
             Node::Static(StaticNode::U128(number)) => self.write_int(number),
-            Node::Static(StaticNode::F64(number)) => self.write_float(number),
+            Node::Static(StaticNode::F64(number)) => self.write_float(number.into()),
             Node::Static(StaticNode::Bool(true)) => self.write(b"true"),
             Node::Static(StaticNode::Bool(false)) => self.write(b"false"),
             Node::String(string) => self.write_string(string),
@@ -819,7 +819,7 @@ trait FastGenerator: BaseGenerator {
             Node::Static(StaticNode::U64(number)) => self.write_int(number),
             #[cfg(feature = "128bit")]
             Node::Static(StaticNode::U128(number)) => self.write_int(number),
-            Node::Static(StaticNode::F64(number)) => self.write_float(number),
+            Node::Static(StaticNode::F64(number)) => self.write_float(number.into()),
             Node::Static(StaticNode::Bool(true)) => self.write(b"true"),
             Node::Static(StaticNode::Bool(false)) => self.write(b"false"),
             Node::String(string) => self.write_string(string),

--- a/src/value/tape/trait_impls.rs
+++ b/src/value/tape/trait_impls.rs
@@ -738,6 +738,7 @@ trait Generator: BaseGenerator {
             Node::Static(StaticNode::U64(number)) => self.write_int(number),
             #[cfg(feature = "128bit")]
             Node::Static(StaticNode::U128(number)) => self.write_int(number),
+            #[allow(clippy::useless_conversion)] // .into() required by ordered-float
             Node::Static(StaticNode::F64(number)) => self.write_float(number.into()),
             Node::Static(StaticNode::Bool(true)) => self.write(b"true"),
             Node::Static(StaticNode::Bool(false)) => self.write(b"false"),
@@ -819,6 +820,7 @@ trait FastGenerator: BaseGenerator {
             Node::Static(StaticNode::U64(number)) => self.write_int(number),
             #[cfg(feature = "128bit")]
             Node::Static(StaticNode::U128(number)) => self.write_int(number),
+            #[allow(clippy::useless_conversion)] // .into() required by ordered-float
             Node::Static(StaticNode::F64(number)) => self.write_float(number.into()),
             Node::Static(StaticNode::Bool(true)) => self.write(b"true"),
             Node::Static(StaticNode::Bool(false)) => self.write(b"false"),

--- a/tests/ordered_float.rs
+++ b/tests/ordered_float.rs
@@ -1,0 +1,26 @@
+// A small test to show that ordered-float does allow us to "do stuff" Eq-wise
+// with values when we opt for an Eq-compatible representation of floats.
+// Easiest way is simply to construct a type that derives Eq and include
+// simd Values in it, construct it, and compare it! This won't even compile 
+// if we have got it wrong
+#[cfg(feature = "ordered-float")]
+use simd_json::{BorrowedValue, OwnedValue};
+
+#[cfg(feature = "ordered-float")]
+#[test]
+fn test_values_as_hashmap_keys() {
+	#[derive(Eq, PartialEq, Debug)]
+	struct AnEqType {
+		owned_value: OwnedValue,
+		borrowed_value: BorrowedValue<'static>
+	}
+	let an_eq_type = AnEqType {
+		owned_value: OwnedValue::from("an-owned-value"),
+		borrowed_value: BorrowedValue::from("a-borrowed-value")
+	};
+
+	assert_eq!(an_eq_type, AnEqType {
+		owned_value: OwnedValue::from("an-owned-value"),
+		borrowed_value: BorrowedValue::from("a-borrowed-value")
+	});
+}

--- a/tests/ordered_float.rs
+++ b/tests/ordered_float.rs
@@ -1,7 +1,7 @@
 // A small test to show that ordered-float does allow us to "do stuff" Eq-wise
 // with values when we opt for an Eq-compatible representation of floats.
 // Easiest way is simply to construct a type that derives Eq and include
-// simd Values in it, construct it, and compare it! This won't even compile 
+// simd Values in it, construct it, and compare it! This won't even compile
 // if we have got it wrong
 #[cfg(feature = "ordered-float")]
 use simd_json::{BorrowedValue, OwnedValue};
@@ -9,18 +9,21 @@ use simd_json::{BorrowedValue, OwnedValue};
 #[cfg(feature = "ordered-float")]
 #[test]
 fn test_values_as_hashmap_keys() {
-	#[derive(Eq, PartialEq, Debug)]
-	struct AnEqType {
-		owned_value: OwnedValue,
-		borrowed_value: BorrowedValue<'static>
-	}
-	let an_eq_type = AnEqType {
-		owned_value: OwnedValue::from("an-owned-value"),
-		borrowed_value: BorrowedValue::from("a-borrowed-value")
-	};
+    #[derive(Eq, PartialEq, Debug)]
+    struct AnEqType {
+        owned_value: OwnedValue,
+        borrowed_value: BorrowedValue<'static>,
+    }
+    let an_eq_type = AnEqType {
+        owned_value: OwnedValue::from("an-owned-value"),
+        borrowed_value: BorrowedValue::from("a-borrowed-value"),
+    };
 
-	assert_eq!(an_eq_type, AnEqType {
-		owned_value: OwnedValue::from("an-owned-value"),
-		borrowed_value: BorrowedValue::from("a-borrowed-value")
-	});
+    assert_eq!(
+        an_eq_type,
+        AnEqType {
+            owned_value: OwnedValue::from("an-owned-value"),
+            borrowed_value: BorrowedValue::from("a-borrowed-value")
+        }
+    );
 }


### PR DESCRIPTION
This PR addresses issue #398 by implementing a feature named `ordered-float` that activates the same-named feature in [`value-trait`](https://github.com/simd-lite/value-trait/pull/54) which itself activates the wrapping of floats with [`OrderedFloat`](https://docs.rs/ordered-float/4.4.0/ordered_float/struct.OrderedFloat.html) and thus allows `StaticValue` to be `std::cmp::Eq`. Various feature-related "tweaks" are also implemented, while trying to use as few `#cfg[feature...]` annotations as possible.

Obvious the PR is dependent upon the `value-trait` PR, but while that is pending `Cargo.toml` in this PR's source branch patches the `value-trait` crate source to be the source repo and branch of the `value-trait` PR.