### PR TITLE
Deserializer as Value and restartable

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -213,7 +213,7 @@ impl Error {
         match &self.error {
             ErrorType::Io(_) | ErrorType::InputTooLarge => true,
             ErrorType::InternalError(e) if !matches!(e, crate::InternalError::TapeError) => true,
-            _ => false
+            _ => false,
         }
     }
 
@@ -234,7 +234,8 @@ impl Error {
     #[must_use]
     pub fn is_syntax(&self) -> bool {
         // Lazy? maybe but if it aint something else...
-        matches!(self.error,
+        matches!(
+            self.error,
             ErrorType::InternalError(crate::InternalError::TapeError) | //This seems to get thrown on some syntax errors
             ErrorType::BadKeyType |
             ErrorType::ExpectedArrayComma |
@@ -258,7 +259,8 @@ impl Error {
             ErrorType::ExpectedObjectContent |
             ErrorType::ExpectedObjectKey |
             ErrorType::Overflow |
-            ErrorType::SimdUnsupported)
+            ErrorType::SimdUnsupported
+        )
     }
 }
 impl std::error::Error for Error {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -211,7 +211,7 @@ impl Error {
     pub fn is_io(&self) -> bool {
         // We have to include InternalError _somewhere_
         match &self.error {
-            ErrorType::Io(_) => true,
+            ErrorType::Io(_) | ErrorType::InputTooLarge => true,
             ErrorType::InternalError(e) if !matches!(e, crate::InternalError::TapeError) => true,
             _ => false
         }
@@ -236,7 +236,6 @@ impl Error {
         // Lazy? maybe but if it aint something else...
         matches!(self.error,
             ErrorType::InternalError(crate::InternalError::TapeError) | //This seems to get thrown on some syntax errors
-            ErrorType::InputTooLarge |
             ErrorType::BadKeyType |
             ErrorType::ExpectedArrayComma |
             ErrorType::ExpectedObjectColon |

--- a/src/error.rs
+++ b/src/error.rs
@@ -219,17 +219,42 @@ impl Error {
         matches!(self.error, ErrorType::Eof)
     }
 
-    /// Indicates if the error that occurred was due to a deserializer error
+    /// Indicates if the error that occurred was due to a data shape error
     #[must_use]
     pub fn is_data(&self) -> bool {
-        matches!(self.error, ErrorType::Parser | ErrorType::Serde(_))
+        // Lazy? maybe but if it aint something else...
+        !(self.is_syntax() || self.is_eof() || self.is_io())
     }
 
-    /// Indicates if the error that occurred was due an input syntax error
+    /// Indicates if the error that occurred was due a JSON syntax error
     #[must_use]
     pub fn is_syntax(&self) -> bool {
         // Lazy? maybe but if it aint something else...
-        !(self.is_data() || self.is_eof() || self.is_io())
+        matches!(self.error, 
+            ErrorType::InputTooLarge |
+            ErrorType::BadKeyType |
+            ErrorType::ExpectedArrayComma |
+            ErrorType::ExpectedObjectColon |
+            ErrorType::ExpectedMapComma |
+            ErrorType::ExpectedMapEnd |
+            ErrorType::InvalidEscape |
+            ErrorType::InvalidExponent |
+            ErrorType::InvalidNumber |
+            ErrorType::InvalidUtf8 |
+            ErrorType::InvalidUnicodeEscape |
+            ErrorType::InvalidUnicodeCodepoint |
+            ErrorType::KeyMustBeAString |
+            ErrorType::NoStructure |
+            ErrorType::Parser |
+            ErrorType::Syntax |
+            ErrorType::TrailingData |
+            ErrorType::UnexpectedCharacter |
+            ErrorType::UnterminatedString |
+            ErrorType::ExpectedArrayContent |
+            ErrorType::ExpectedObjectContent |
+            ErrorType::ExpectedObjectKey |
+            ErrorType::Overflow |
+            ErrorType::SimdUnsupported)
     }
 }
 impl std::error::Error for Error {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -210,7 +210,11 @@ impl Error {
     #[must_use]
     pub fn is_io(&self) -> bool {
         // We have to include InternalError _somewhere_
-        matches!(self.error, ErrorType::Io(_) | ErrorType::InternalError(_))
+        match &self.error {
+            ErrorType::Io(_) => true,
+            ErrorType::InternalError(e) if !matches!(e, crate::InternalError::TapeError) => true,
+            _ => false
+        }
     }
 
     /// Indicates if the error that occurred was an early EOF
@@ -230,7 +234,8 @@ impl Error {
     #[must_use]
     pub fn is_syntax(&self) -> bool {
         // Lazy? maybe but if it aint something else...
-        matches!(self.error, 
+        matches!(self.error,
+            ErrorType::InternalError(crate::InternalError::TapeError) | //This seems to get thrown on some syntax errors
             ErrorType::InputTooLarge |
             ErrorType::BadKeyType |
             ErrorType::ExpectedArrayComma |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,6 +281,7 @@ pub(crate) trait Stage1Parse {
 }
 
 /// Deserializer struct to deserialize a JSON
+#[derive(Debug)]
 pub struct Deserializer<'de> {
     // Note: we use the 2nd part as both index and length since only one is ever
     // used (array / object use len) everything else uses idx

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1127,11 +1127,11 @@ mod tests {
         let v = d.as_value();
 
         assert!(v.contains_key("payload"), "Failed to find payload key");
-        let v = v.get("payload").unwrap();
-        assert!(v.is_object(), "payload not recognized as object: {:?}", v);
+        let v = v.get("payload").expect("Can't get payload");
+        assert!(v.is_object(), "payload not recognized as object: {v:?}");
         assert!(v.contains_key("features"), "Failed to find features key");
-        let v = v.get("features").unwrap();
-        assert!(v.is_array(), "features not recognized as array: {:?}", v);
+        let v = v.get("features").expect("can't get features");
+        assert!(v.is_array(), "features not recognized as array: {v:?}");
 
         // proving that value peeking doesn't affect the deserializer
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1090,8 +1090,8 @@ impl DerefMut for AlignedBuf {
 
 #[cfg(test)]
 mod tests {
-    use serde_ext::Deserialize;
     use crate::Deserializer;
+    use serde_ext::Deserialize;
 
     static JSON: &str = r#"{
         "code": 200,
@@ -1106,14 +1106,14 @@ mod tests {
 
     #[derive(Deserialize, PartialEq, Debug)]
     struct TestPayload {
-        features: Vec<String>
+        features: Vec<String>,
     }
 
     #[derive(Deserialize, PartialEq, Debug)]
     struct TestEnvelope {
         code: usize,
         success: bool,
-        payload: TestPayload
+        payload: TestPayload,
     }
 
     #[test]
@@ -1135,11 +1135,18 @@ mod tests {
 
         // proving that value peeking doesn't affect the deserializer
 
-        assert_eq!(original_index, d.idx, "Deserializer has been internally modified");
-        assert_eq!(original_nodes, d.tape.len(), "Deserializer has been internally modified");
+        assert_eq!(
+            original_index, d.idx,
+            "Deserializer has been internally modified"
+        );
+        assert_eq!(
+            original_nodes,
+            d.tape.len(),
+            "Deserializer has been internally modified"
+        );
     }
 
-     #[test]
+    #[test]
     fn test_deser_restart() {
         let mut json = JSON.as_bytes().to_vec();
         let mut d = Deserializer::from_slice(&mut json).expect("Invalid JSON");
@@ -1149,12 +1156,20 @@ mod tests {
 
         let test1 = TestEnvelope::deserialize(&mut d).expect("Deserialization failed");
 
-        assert!(original_index != d.idx, "Deserializer has NOT been internally modified");
-        assert_eq!(original_nodes, d.tape.len(), "Deserializer nodes are NOT intact");
+        assert!(
+            original_index != d.idx,
+            "Deserializer has NOT been internally modified"
+        );
+        assert_eq!(
+            original_nodes,
+            d.tape.len(),
+            "Deserializer nodes are NOT intact"
+        );
 
         d.restart();
 
         let test2 = TestEnvelope::deserialize(&mut d).expect("Deserialization failed");
 
         assert_eq!(test2, test1, "Deserializer is not idempotent");
-    }}
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1089,4 +1089,72 @@ impl DerefMut for AlignedBuf {
 }
 
 #[cfg(test)]
-mod tests;
+mod tests {
+    use serde_ext::Deserialize;
+    use crate::Deserializer;
+
+    static JSON: &str = r#"{
+        "code": 200,
+        "success": true,
+        "payload": {
+            "features": [
+                "serde",
+                "json"
+            ]
+        }
+    }"#;
+
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct TestPayload {
+        features: Vec<String>
+    }
+
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct TestEnvelope {
+        code: usize,
+        success: bool,
+        payload: TestPayload
+    }
+
+    #[test]
+    fn test_deser_to_value() {
+        let mut json = JSON.as_bytes().to_vec();
+        let d = Deserializer::from_slice(&mut json).expect("Invalid JSON");
+
+        let original_index = d.idx;
+        let original_nodes = d.tape.len();
+
+        let v = d.as_value();
+
+        assert!(v.contains_key("payload"), "Failed to find payload key");
+        let v = v.get("payload").unwrap();
+        assert!(v.is_object(), "payload not recognized as object: {:?}", v);
+        assert!(v.contains_key("features"), "Failed to find features key");
+        let v = v.get("features").unwrap();
+        assert!(v.is_array(), "features not recognized as array: {:?}", v);
+
+        // proving that value peeking doesn't affect the deserializer
+
+        assert_eq!(original_index, d.idx, "Deserializer has been internally modified");
+        assert_eq!(original_nodes, d.tape.len(), "Deserializer has been internally modified");
+    }
+
+     #[test]
+    fn test_deser_restart() {
+        let mut json = JSON.as_bytes().to_vec();
+        let mut d = Deserializer::from_slice(&mut json).expect("Invalid JSON");
+
+        let original_index = d.idx;
+        let original_nodes = d.tape.len();
+
+        let test1 = TestEnvelope::deserialize(&mut d).expect("Deserialization failed");
+
+        assert!(original_index != d.idx, "Deserializer has NOT been internally modified");
+        assert_eq!(original_nodes, d.tape.len(), "Deserializer nodes are NOT intact");
+
+        d.restart();
+
+        let test2 = TestEnvelope::deserialize(&mut d).expect("Deserialization failed");
+
+        assert_eq!(test2, test1, "Deserializer is not idempotent");
+    }}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ mod stringparse;
 
 use safer_unchecked::GetSaferUnchecked;
 use stage2::StackState;
+use tape::Value;
 
 mod impls;
 
@@ -719,6 +720,19 @@ impl<'de> Deserializer<'de> {
     #[must_use]
     pub fn into_tape(self) -> Tape<'de> {
         Tape(self.tape)
+    }
+
+    /// Gives a `Value` view of the tape in the Deserializer
+    #[must_use]
+    pub fn as_value(&self) -> Value<'_, 'de> {
+        // Skip initial zero
+        Value(&self.tape)
+    }
+
+    /// Resets the Deserializer tape index to 0
+    pub fn restart(&mut self) {
+        // Skip initial zero
+        self.idx = 0;
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1088,6 +1088,7 @@ impl DerefMut for AlignedBuf {
     }
 }
 
+#[cfg(feature = "serde_impl")] //since the tested features are there to help work better with serde ...
 #[cfg(test)]
 mod tests {
     use crate::Deserializer;

--- a/src/value/tape.rs
+++ b/src/value/tape.rs
@@ -56,7 +56,7 @@ impl<'input> Tape<'input> {
 /// Wrapper around the tape that allows interaction via a `Value`-like API.
 #[derive(Clone, Copy, Debug)]
 #[repr(transparent)]
-pub struct Value<'tape, 'input>(pub(super) &'tape [Node<'input>])
+pub struct Value<'tape, 'input>(pub(crate) &'tape [Node<'input>])
 where
     'input: 'tape;
 


### PR DESCRIPTION
This is kind of a prereq for any RawValue-like capability. 

As ever, 'my' use case requires the Deserialize to "introspect" or "peek at" the JSON, possibly multiple times, in order to "try" possibly multiple different "sub deserializations" for an Enum. With `serde_json::RawValue`, you have access to the string slice that backs the value, so the code tries that string as various different types (enabled by features). 

Because `simd_json` doesn't seem to keep the string around (and, anyway, it's a mutated bytes buf), the alternative is to introspect the Node vector held by the deserializer. Hence `as_value`. 

Additionally, reusing the Deserializer - which multiple attempted deserializations would require - won't work without some sort of "start again" operation since a deserialization moves the "cursor" (updates the internal index) ... hence `restart`.

in _my_ use case this (almost unbelievably) works! 

Now, safely getting _access_ to the type-specific methods of the deserializer passed into `Deserialize::deserialize` ... well, that's where the _future_ RawValue feature will come in. At the moment, though, I do it with some wildly unsafe casting (which is actually ALMOST legitimate in my case because there is "no way" the Deserializer _couldn't_ be a simd_json::Deserializer at the point  I'm do the cast - famous last words, eh!).