### PR TITLE
Remove line about being tested with Miri

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ There are a few reasons for this:
   don't panic or crash the parser (they might and often error so - they are not valid JSON!)
 * Destructive Property based testing - make sure that no illegal byte sequences crash the parser in any way
 * Fuzzing - fuzz based on upstream & jsonorg simd pass/fail cases
-* Miri testing for UB
 
 This doesn't ensure complete safety nor is at a bulletproof guarantee, but it does go a long way
 to assert that the library is of high production quality and fit for purpose for practical industrial applications.


### PR DESCRIPTION
Miri has been disabled since August 2023 (https://github.com/simd-lite/simd-json/commit/a03d8f979e095b36ee1a16ff280e21a6ef4b9933) with no obvious movement to re-enable testing. Removing it as a tagline feature will help to remove any uncertainty or bad feelings about this project unintentionally lying about miri UB testing.