### PR TITLE
Remove a starting underscore in floating point exponent

### DIFF
--- a/src/numberparse/correct.rs
+++ b/src/numberparse/correct.rs
@@ -566,7 +566,7 @@ mod test {
     fn minus_309() -> Result<(), crate::Error> {
         assert_eq!(
             to_value_from_str("-5.96916642387374e-309")?,
-            Static(StaticNode::from(-5.969_166_423_873_74e-_309))
+            Static(StaticNode::from(-5.969_166_423_873_74e-309))
         );
         Ok(())
     }


### PR DESCRIPTION
This is a questionable feature in Rust lexer and `simd-json` is the only known crate on crates.io that is using it. It's not being removed *yet*, but it would still be better to avoid using it.

See https://github.com/rust-lang/rust/pull/137394 and linked issues for more details.