### PR TITLE
Add warning for from_reader to improve documentation

### DIFF
--- a/src/serde.rs
+++ b/src/serde.rs
@@ -135,6 +135,13 @@ where
 
 /// parses a Reader using a serde deserializer.
 ///
+/// # Warning
+///     
+/// Since simd-json does not support streaming and requires mutability of the data, this function
+/// will read the entire reader into memory before parsing it.
+///
+/// You might do better using `from_slice` and managing the read buffer yourself.
+///
 /// # Errors
 ///
 /// Will return `Err` if an IO error is encountered while reading


### PR DESCRIPTION
Document the behavior of `from_reader`, highlighting that it reads the entire input into memory before parsing. This change addresses potential performance concerns and clarifies that it does not support streaming. Suggest using `from_slice` for better memory management.

Fixes #417