### PR TITLE
Refactor imports to use macros for static casts and improve code organization

### DIFF
--- a/src/impls/avx2/deser.rs
+++ b/src/impls/avx2/deser.rs
@@ -12,6 +12,7 @@ use arch::{
 use crate::{
     Deserializer, Result, SillyWrapper,
     error::ErrorType,
+    macros::static_cast_u32,
     safer_unchecked::GetSaferUnchecked,
     stringparse::{ESCAPE_MAP, handle_unicode_codepoint},
 };

--- a/src/impls/avx2/stage1.rs
+++ b/src/impls/avx2/stage1.rs
@@ -1,5 +1,8 @@
 #![allow(dead_code)]
-use crate::{Stage1Parse, static_cast_i32, static_cast_i64, static_cast_u32};
+use crate::{
+    Stage1Parse,
+    macros::{static_cast_i32, static_cast_i64, static_cast_u32},
+};
 #[cfg(target_arch = "x86")]
 use std::arch::x86 as arch;
 

--- a/src/impls/native/stage1.rs
+++ b/src/impls/native/stage1.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::cast_lossless, clippy::cast_sign_loss)]
 
-use crate::{Stage1Parse, static_cast_i32};
+use crate::{Stage1Parse, macros::static_cast_i32};
 
 type V128 = [u8; 16];
 

--- a/src/impls/neon/stage1.rs
+++ b/src/impls/neon/stage1.rs
@@ -1,4 +1,4 @@
-use crate::{Stage1Parse, static_cast_i32};
+use crate::Stage1Parse;
 use std::arch::aarch64::{
     int8x16_t, int32x4_t, uint8x16_t, vaddq_s32, vandq_u8, vceqq_u8, vcleq_u8, vdupq_n_s8,
     vgetq_lane_u64, vld1q_u8, vmovq_n_u8, vpaddq_u8, vqtbl1q_u8, vreinterpretq_u8_s8,

--- a/src/impls/portable/stage1.rs
+++ b/src/impls/portable/stage1.rs
@@ -1,6 +1,6 @@
 use std::simd::{ToBitMask, prelude::*};
 
-use crate::{Stage1Parse, static_cast_i32};
+use crate::{Stage1Parse, macros::static_cast_i32};
 #[derive(Debug)]
 pub(crate) struct SimdInput {
     v: u8x64,

--- a/src/impls/sse42/stage1.rs
+++ b/src/impls/sse42/stage1.rs
@@ -1,4 +1,7 @@
-use crate::{Stage1Parse, static_cast_i32, static_cast_u32};
+use crate::{
+    Stage1Parse,
+    macros::{static_cast_i32, static_cast_i64, static_cast_u32},
+};
 #[cfg(target_arch = "x86")]
 use std::arch::x86 as arch;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ mod numberparse;
 mod safer_unchecked;
 mod stringparse;
 
+use macros::static_cast_u64;
 use safer_unchecked::GetSaferUnchecked;
 use stage2::StackState;
 use tape::Value;
@@ -54,9 +55,9 @@ mod impls;
 pub mod cow;
 
 /// The maximum padding size required by any SIMD implementation
-pub const SIMDJSON_PADDING: usize = 32; // take upper limit mem::size_of::<__m256i>()
+pub(crate) const SIMDJSON_PADDING: usize = 32; // take upper limit mem::size_of::<__m256i>()
 /// It's 64 for all (Is this correct?)
-pub const SIMDINPUT_LENGTH: usize = 64;
+pub(crate) const SIMDINPUT_LENGTH: usize = 64;
 
 mod stage2;
 /// simd-json JSON-DOM value

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1191,48 +1191,16 @@ macro_rules! json_unexpected {
     () => {};
 }
 
-/// possible compiler hint that a branch is likely
-#[cfg(feature = "hints")]
-#[macro_export]
-macro_rules! likely {
-    ($e:expr) => {
-        ::std::intrinsics::likely($e)
-    };
-}
-
 /// possible compiler hint that a branch is unlikely
 #[cfg(feature = "hints")]
-#[macro_export]
 macro_rules! unlikely {
     ($e:expr) => {{ ::std::intrinsics::unlikely($e) }};
 }
 
-/// possible compiler hint that a branch is likely
-///
-/// Technique borrowed from here: <https://github.com/rust-lang/hashbrown/pull/209>
-#[cfg(not(feature = "hints"))]
-#[macro_export]
-macro_rules! likely {
-    ($e:expr_2021) => {{
-        #[inline]
-        #[cold]
-        fn cold() {}
-
-        let cond = $e;
-
-        if !cond {
-            cold();
-        }
-
-        cond
-    }};
-}
-
 /// possible compiler hint that a branch is unlikely
 ///
 /// Technique borrowed from here: <https://github.com/rust-lang/hashbrown/pull/209>
 #[cfg(not(feature = "hints"))]
-#[macro_export]
 macro_rules! unlikely {
     ($e:expr_2021) => {{
         #[inline]
@@ -1249,61 +1217,60 @@ macro_rules! unlikely {
     }};
 }
 
-/// static cast to an i8
-#[macro_export]
-macro_rules! static_cast_i8 {
-    ($v:expr_2021) => {
-        ::std::transmute::<_, i8>($v)
-    };
-}
+pub(crate) use unlikely;
 
 /// static cast to an i32
-#[macro_export]
+#[allow(unused_macros)]
 macro_rules! static_cast_i32 {
     ($v:expr_2021) => {
         ::std::mem::transmute::<u32, i32>($v)
     };
 }
+#[allow(unused_imports)]
+pub(crate) use static_cast_i32;
 
 /// static cast to an u32
-#[macro_export]
+#[allow(unused_macros)]
 macro_rules! static_cast_u32 {
     ($v:expr_2021) => {
         // #[allow(clippy::missing_transmute_annotations)]
         ::std::mem::transmute::<i32, u32>($v)
     };
 }
+#[allow(unused_imports)]
+pub(crate) use static_cast_u32;
 
 /// static cast to an i64
-#[macro_export]
 macro_rules! static_cast_i64 {
     ($v:expr_2021) => {
         ::std::mem::transmute::<u64, i64>($v)
     };
 }
+pub(crate) use static_cast_i64;
 
 /// static cast to an i64
-#[macro_export]
+#[cfg(all(feature = "approx-number-parsing", feature = "i128"))]
 macro_rules! static_cast_i128 {
     ($v:expr_2021) => {
         ::std::mem::transmute::<_, i128>($v)
     };
 }
+#[cfg(all(feature = "approx-number-parsing", feature = "i128"))]
+pub(crate) use static_cast_i128;
 
 /// static cast to an u64
-#[macro_export]
 macro_rules! static_cast_u64 {
     ($v:expr_2021) => {
         ::std::mem::transmute::<i64, u64>($v)
     };
 }
+pub(crate) use static_cast_u64;
 
 /// Custom `try!` macro that does no `From` conversions
 ///
 /// FROM serde-json
 /// We only use our own error type; no need for From conversions provided by the
 /// standard library's try! macro. This reduces lines of LLVM IR by 4%.
-#[macro_export]
 macro_rules! stry {
     ($e:expr_2021) => {
         match $e {
@@ -1312,6 +1279,8 @@ macro_rules! stry {
         }
     };
 }
+#[allow(unused_imports)]
+pub(crate) use stry;
 
 #[cfg(test)]
 mod test {

--- a/src/numberparse/approx.rs
+++ b/src/numberparse/approx.rs
@@ -4,6 +4,7 @@ use super::{
 };
 use crate::StaticNode;
 use crate::charutils::is_structural_or_whitespace;
+use crate::macros::{static_cast_i64, unlikely};
 use crate::safer_unchecked::GetSaferUnchecked;
 use crate::{Deserializer, ErrorType, Result};
 

--- a/src/numberparse/correct.rs
+++ b/src/numberparse/correct.rs
@@ -9,6 +9,7 @@ use super::{is_made_of_eight_digits_fast, parse_eight_digits_unrolled};
 use crate::StaticNode;
 use crate::charutils::is_structural_or_whitespace;
 use crate::error::Error;
+use crate::macros::{static_cast_i64, unlikely};
 use crate::safer_unchecked::GetSaferUnchecked;
 use crate::{Deserializer, ErrorType, Result};
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -12,7 +12,7 @@ mod value;
 pub use self::se::*;
 pub use self::value::*;
 use crate::{BorrowedValue, OwnedValue};
-use crate::{Buffers, Deserializer, Error, ErrorType, Node, Result, stry};
+use crate::{Buffers, Deserializer, Error, ErrorType, Node, Result, macros::stry};
 use serde::de::DeserializeOwned;
 use serde_ext::Deserialize;
 use std::fmt;

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -1,5 +1,5 @@
 use crate::serde_ext::de::IntoDeserializer;
-use crate::{Deserializer, Error, ErrorType, Node, Result, StaticNode, stry};
+use crate::{Deserializer, Error, ErrorType, Node, Result, StaticNode, macros::stry};
 use serde_ext::de::{self, DeserializeSeed, MapAccess, SeqAccess, Visitor};
 use serde_ext::forward_to_deserialize_any;
 use std::str;

--- a/src/serde/se/pp.rs
+++ b/src/serde/se/pp.rs
@@ -1,4 +1,4 @@
-use crate::{Error, ErrorType, stry};
+use crate::{Error, ErrorType, macros::stry};
 use serde_ext::ser;
 use std::io::Write;
 use std::str;

--- a/src/serde/value/borrowed/se.rs
+++ b/src/serde/value/borrowed/se.rs
@@ -2,7 +2,7 @@ use super::to_value;
 use crate::{
     Error, ErrorType, Result,
     cow::Cow,
-    stry,
+    macros::stry,
     value::borrowed::{Object, Value},
 };
 use crate::{ObjectHasher, StaticNode};

--- a/src/serde/value/owned/se.rs
+++ b/src/serde/value/owned/se.rs
@@ -1,6 +1,7 @@
 use super::to_value;
 use crate::{
-    Error, ErrorType, ObjectHasher, Result, StaticNode, stry,
+    Error, ErrorType, ObjectHasher, Result, StaticNode,
+    macros::stry,
     value::owned::{Object, Value},
 };
 use serde_ext::ser::{

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 use crate::charutils::is_not_structural_or_whitespace;
+use crate::macros::unlikely;
 use crate::safer_unchecked::GetSaferUnchecked;
 use crate::value::tape::Node;
 use crate::{Deserializer, Error, ErrorType, InternalError, Result};


### PR DESCRIPTION
Refactor the code to enhance organization by utilizing macros for static casts. This change simplifies import statements and improves overall code clarity.