### PR TITLE
Remove debug statement from serialization function

### DIFF
--- a/src/serde/se/pp.rs
+++ b/src/serde/se/pp.rs
@@ -256,7 +256,6 @@ where
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
     fn serialize_str(self, value: &str) -> Result<(), Self::Error> {
-        dbg!(value);
         self.s.serialize_str(value)
     }
 


### PR DESCRIPTION
Eliminate the debug output in the `serialize_str` function to clean up the code.