### PR TITLE
fix: Miri error on invalidated mut borrow

### DIFF
--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -111,6 +111,8 @@ impl<'de> Deserializer<'de> {
         stack.clear();
         stack.reserve(structural_indexes.len());
 
+        // Safety: Must NOT advance input pointer as part of logic, since we only get the pointer once.
+        // Use idx in order to advance through the input.
         let input_ptr = input.as_mut_ptr();
         let res_ptr = res.as_mut_ptr();
         let stack_ptr = stack.as_mut_ptr();
@@ -186,10 +188,7 @@ impl<'de> Deserializer<'de> {
         macro_rules! insert_str {
             () => {
                 insert_res!(Node::String(s2try!(Self::parse_str_(
-                    input_ptr,
-                    &input2,
-                    buffer,
-                    idx
+                    input_ptr, &input2, buffer, idx
                 ))));
             };
         }

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -111,6 +111,7 @@ impl<'de> Deserializer<'de> {
         stack.clear();
         stack.reserve(structural_indexes.len());
 
+        let input_ptr = input.as_mut_ptr();
         let res_ptr = res.as_mut_ptr();
         let stack_ptr = stack.as_mut_ptr();
 
@@ -185,7 +186,7 @@ impl<'de> Deserializer<'de> {
         macro_rules! insert_str {
             () => {
                 insert_res!(Node::String(s2try!(Self::parse_str_(
-                    input.as_mut_ptr(),
+                    input_ptr,
                     &input2,
                     buffer,
                     idx


### PR DESCRIPTION
Because the function continuously mutates the data in the input mut slice, miri's borrow checker invalidates the original mut borrow, so calling input.as_mut_ptr() is not allowed(miri no longer guarantees the validity of `input`)
This can be fixed by calling input.as_mut_ptr()  once and using that var