### PR TITLE
Add approx integer parsing error-path test coverage

### DIFF
--- a/src/numberparse/approx.rs
+++ b/src/numberparse/approx.rs
@@ -562,9 +562,17 @@ impl Deserializer<'_> {
 #[cfg(test)]
 mod test {
     #![allow(clippy::default_trait_access)]
+    use crate::error::Error;
+    use crate::value::owned::Value;
     use crate::value::owned::to_value;
     use float_cmp::approx_eq;
     use value_trait::prelude::*;
+
+    fn to_value_from_str(buf: &str) -> Result<Value, Error> {
+        let mut val = String::from(buf);
+        let val = unsafe { val.as_bytes_mut() };
+        to_value(val)
+    }
 
     #[test]
     fn bad_exp() {
@@ -679,5 +687,66 @@ mod test {
         let mut i = unsafe { i.as_bytes_mut() };
         let r = to_value(&mut i).expect("failed to decode");
         assert!(approx_eq!(f64, r.as_f64().expect("float"), -0.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000596916642387374));
+    }
+
+    #[test]
+    fn int_trailing_invalid() {
+        // The byte terminating an integer must be structural-or-whitespace. An
+        // embedded NUL, a trailing letter or a digit separator are none of those
+        // and must be rejected.
+        assert!(to_value_from_str("123\x00").is_err());
+        assert!(to_value_from_str("[123\x00]").is_err());
+        assert!(to_value_from_str("123a").is_err());
+        assert!(to_value_from_str("1a").is_err());
+        assert!(to_value_from_str("[123a]").is_err());
+        assert!(to_value_from_str("[1a]").is_err());
+        // digit separators (e.g. Rust's `1_000`) are not valid JSON
+        assert!(to_value_from_str("1_000").is_err());
+    }
+
+    #[test]
+    fn int_leading_zero() {
+        // JSON forbids leading zeroes: a `0` may only be followed by a
+        // structural/whitespace/exponent/decimal byte, never another digit.
+        assert!(to_value_from_str("01").is_err());
+        assert!(to_value_from_str("00").is_err());
+        assert!(to_value_from_str("012").is_err());
+        assert!(to_value_from_str("0123").is_err());
+        assert!(to_value_from_str("-01").is_err());
+        assert!(to_value_from_str("-00").is_err());
+        assert!(to_value_from_str("[01]").is_err());
+        assert!(to_value_from_str("[-01]").is_err());
+    }
+
+    #[test]
+    fn int_zero_prefix() {
+        // A `0` followed by a base prefix (hex/binary/octal) is not valid JSON.
+        assert!(to_value_from_str("0x1").is_err());
+        assert!(to_value_from_str("0X1").is_err());
+        assert!(to_value_from_str("0b1").is_err());
+        assert!(to_value_from_str("0o1").is_err());
+        assert!(to_value_from_str("[0x1]").is_err());
+    }
+
+    #[test]
+    fn int_bare_sign() {
+        // A `-` must be followed by a digit.
+        assert!(to_value_from_str("-").is_err());
+        assert!(to_value_from_str("-x").is_err());
+        assert!(to_value_from_str("-e5").is_err());
+        assert!(to_value_from_str("-.5").is_err());
+    }
+
+    #[test]
+    fn int_bad_exponent() {
+        // An integer carrying an exponent marker still needs at least one
+        // exponent digit; a bare sign after `e`/`E` is not enough.
+        assert!(to_value_from_str("1e").is_err());
+        assert!(to_value_from_str("2E").is_err());
+        assert!(to_value_from_str("1e+").is_err());
+        assert!(to_value_from_str("1e-").is_err());
+        assert!(to_value_from_str("9e+").is_err());
+        assert!(to_value_from_str("[1e]").is_err());
+        assert!(to_value_from_str("[9e-]").is_err());
     }
 }


### PR DESCRIPTION
Follows up on #465 — the maintainer offered to merge the same coverage for the approx parser.

## What

- Add `InvalidNumber` error-path tests for the `approx-number-parsing` integer parser, mirroring the correct-parser coverage from #465.
  - Covers leading zeroes, base prefixes (`0x`/`0b`/`0o`), a bare/invalid sign, an exponent marker with no digits, and non-terminator trailing bytes.
- Add a `to_value_from_str` test helper matching the one in `correct.rs`.

## Notes

- Test-only change: `approx.rs`'s `parse_number` already rejected these inputs, the paths were simply untested.
- Verified with `cargo test --features approx-number-parsing` and `cargo fmt --check`.
