### PR TITLE
Make simd idiomatic

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1264,16 +1264,16 @@ pub(crate) use static_cast_u64;
 /// FROM serde-json
 /// We only use our own error type; no need for From conversions provided by the
 /// standard library's try! macro. This reduces lines of LLVM IR by 4%.
-macro_rules! stry {
-    ($e:expr_2021) => {
-        match $e {
-            ::std::result::Result::Ok(val) => val,
-            ::std::result::Result::Err(err) => return ::std::result::Result::Err(err),
-        }
-    };
-}
-#[allow(unused_imports)]
-pub(crate) use stry;
+// macro_rules! stry {
+//     ($e:expr_2021) => {
+//         match $e {
+//             ::std::result::Result::Ok(val) => val,
+//             ::std::result::Result::Err(err) => return ::std::result::Result::Err(err),
+//         }
+//     };
+// }
+// #[allow(unused_imports)]
+// pub(crate) use stry;
 
 #[cfg(test)]
 mod test {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -125,10 +125,8 @@ pub unsafe fn from_str_with_buffers<'a, T>(s: &'a mut str, buffers: &mut Buffers
 where
     T: Deserialize<'a>,
 {
-    let mut deserializer = Deserializer::from_slice_with_buffers(
-        unsafe { s.as_bytes_mut() },
-        buffers
-    )?;
+    let mut deserializer =
+        Deserializer::from_slice_with_buffers(unsafe { s.as_bytes_mut() }, buffers)?;
 
     T::deserialize(&mut deserializer)
 }
@@ -178,7 +176,7 @@ where
     if let Err(e) = rdr.read_to_end(&mut data) {
         return Err(Error::generic(ErrorType::Io(e)));
     }
-    let mut deserializer =  Deserializer::from_slice_with_buffers(&mut data, buffers)?;
+    let mut deserializer = Deserializer::from_slice_with_buffers(&mut data, buffers)?;
     T::deserialize(&mut deserializer)
 }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -12,7 +12,7 @@ mod value;
 pub use self::se::*;
 pub use self::value::*;
 use crate::{BorrowedValue, OwnedValue};
-use crate::{Buffers, Deserializer, Error, ErrorType, Node, Result, macros::stry};
+use crate::{Buffers, Deserializer, Error, ErrorType, Node, Result};
 use serde::de::DeserializeOwned;
 use serde_ext::Deserialize;
 use std::fmt;
@@ -57,7 +57,7 @@ pub fn from_slice<'a, T>(s: &'a mut [u8]) -> Result<T>
 where
     T: Deserialize<'a>,
 {
-    let mut deserializer = stry!(Deserializer::from_slice(s));
+    let mut deserializer = Deserializer::from_slice(s)?;
     T::deserialize(&mut deserializer)
 }
 
@@ -74,7 +74,7 @@ pub fn from_slice_with_buffers<'a, T>(s: &'a mut [u8], buffers: &mut Buffers) ->
 where
     T: Deserialize<'a>,
 {
-    let mut deserializer = stry!(Deserializer::from_slice_with_buffers(s, buffers));
+    let mut deserializer = Deserializer::from_slice_with_buffers(s, buffers)?;
     T::deserialize(&mut deserializer)
 }
 
@@ -98,7 +98,7 @@ pub unsafe fn from_str<'a, T>(s: &'a mut str) -> Result<T>
 where
     T: Deserialize<'a>,
 {
-    let mut deserializer = stry!(Deserializer::from_slice(unsafe { s.as_bytes_mut() }));
+    let mut deserializer = Deserializer::from_slice(unsafe { s.as_bytes_mut() })?;
 
     T::deserialize(&mut deserializer)
 }
@@ -125,10 +125,10 @@ pub unsafe fn from_str_with_buffers<'a, T>(s: &'a mut str, buffers: &mut Buffers
 where
     T: Deserialize<'a>,
 {
-    let mut deserializer = stry!(Deserializer::from_slice_with_buffers(
+    let mut deserializer = Deserializer::from_slice_with_buffers(
         unsafe { s.as_bytes_mut() },
         buffers
-    ));
+    )?;
 
     T::deserialize(&mut deserializer)
 }
@@ -156,7 +156,7 @@ where
     if let Err(e) = rdr.read_to_end(&mut data) {
         return Err(Error::generic(ErrorType::Io(e)));
     }
-    let mut deserializer = stry!(Deserializer::from_slice(&mut data));
+    let mut deserializer = Deserializer::from_slice(&mut data)?;
     T::deserialize(&mut deserializer)
 }
 
@@ -178,7 +178,7 @@ where
     if let Err(e) = rdr.read_to_end(&mut data) {
         return Err(Error::generic(ErrorType::Io(e)));
     }
-    let mut deserializer = stry!(Deserializer::from_slice_with_buffers(&mut data, buffers));
+    let mut deserializer =  Deserializer::from_slice_with_buffers(&mut data, buffers)?;
     T::deserialize(&mut deserializer)
 }
 
@@ -218,7 +218,7 @@ impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline)]
     #[allow(clippy::cast_sign_loss)]
     fn parse_u8(&mut self) -> Result<u8> {
-        match stry!(self.next()) {
+        match self.next()? {
             Node::Static(s) => s
                 .as_u8()
                 .ok_or_else(|| Self::error(ErrorType::ExpectedUnsigned)),
@@ -229,7 +229,7 @@ impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline)]
     #[allow(clippy::cast_sign_loss)]
     fn parse_u16(&mut self) -> Result<u16> {
-        let next = stry!(self.next());
+        let next = self.next()?;
         match next {
             Node::Static(s) => s
                 .as_u16()
@@ -241,7 +241,7 @@ impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline)]
     #[allow(clippy::cast_sign_loss)]
     fn parse_u32(&mut self) -> Result<u32> {
-        match stry!(self.next()) {
+        match self.next()? {
             Node::Static(s) => s
                 .as_u32()
                 .ok_or_else(|| Self::error(ErrorType::ExpectedUnsigned)),
@@ -252,7 +252,7 @@ impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline)]
     #[allow(clippy::cast_sign_loss)]
     fn parse_u64(&mut self) -> Result<u64> {
-        match stry!(self.next()) {
+        match self.next()? {
             Node::Static(s) => s
                 .as_u64()
                 .ok_or_else(|| Self::error(ErrorType::ExpectedUnsigned)),
@@ -263,7 +263,7 @@ impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline)]
     #[allow(clippy::cast_sign_loss)]
     fn parse_u128(&mut self) -> Result<u128> {
-        match stry!(self.next()) {
+        match self.next()? {
             Node::Static(s) => s
                 .as_u128()
                 .ok_or_else(|| Self::error(ErrorType::ExpectedUnsigned)),
@@ -274,7 +274,7 @@ impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline)]
     #[allow(clippy::cast_sign_loss)]
     fn parse_i8(&mut self) -> Result<i8> {
-        match stry!(self.next()) {
+        match self.next()? {
             Node::Static(s) => s
                 .as_i8()
                 .ok_or_else(|| Self::error(ErrorType::ExpectedSigned)),
@@ -285,7 +285,7 @@ impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline)]
     #[allow(clippy::cast_sign_loss)]
     fn parse_i16(&mut self) -> Result<i16> {
-        match stry!(self.next()) {
+        match self.next()? {
             Node::Static(s) => s
                 .as_i16()
                 .ok_or_else(|| Self::error(ErrorType::ExpectedSigned)),
@@ -296,7 +296,7 @@ impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline)]
     #[allow(clippy::cast_sign_loss)]
     fn parse_i32(&mut self) -> Result<i32> {
-        match stry!(self.next()) {
+        match self.next()? {
             Node::Static(s) => s
                 .as_i32()
                 .ok_or_else(|| Self::error(ErrorType::ExpectedSigned)),
@@ -307,7 +307,7 @@ impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline)]
     #[allow(clippy::cast_sign_loss)]
     fn parse_i64(&mut self) -> Result<i64> {
-        match stry!(self.next()) {
+        match self.next()? {
             Node::Static(s) => s
                 .as_i64()
                 .ok_or_else(|| Self::error(ErrorType::ExpectedSigned)),
@@ -318,7 +318,7 @@ impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline)]
     #[allow(clippy::cast_sign_loss)]
     fn parse_i128(&mut self) -> Result<i128> {
-        match stry!(self.next()) {
+        match self.next()? {
             Node::Static(s) => s
                 .as_i128()
                 .ok_or_else(|| Self::error(ErrorType::ExpectedSigned)),
@@ -329,7 +329,7 @@ impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline)]
     #[allow(clippy::cast_possible_wrap, clippy::cast_precision_loss)]
     fn parse_double(&mut self) -> Result<f64> {
-        match stry!(self.next()) {
+        match self.next()? {
             #[allow(clippy::useless_conversion)] // .into() required by ordered-float
             Node::Static(StaticNode::F64(n)) => Ok(n.into()),
             Node::Static(StaticNode::I64(n)) => Ok(n as f64),

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -1,5 +1,5 @@
 use crate::serde_ext::de::IntoDeserializer;
-use crate::{Deserializer, Error, ErrorType, Node, Result, StaticNode, macros::stry};
+use crate::{Deserializer, Error, ErrorType, Node, Result, StaticNode};
 use serde_ext::de::{self, DeserializeSeed, MapAccess, SeqAccess, Visitor};
 use serde_ext::forward_to_deserialize_any;
 use std::str;
@@ -18,7 +18,7 @@ where
     where
         V: Visitor<'de>,
     {
-        match stry!(self.next()) {
+        match self.next()? {
             Node::String(s) => visitor.visit_borrowed_str(s),
             Node::Static(StaticNode::Null) => visitor.visit_unit(),
             Node::Static(StaticNode::Bool(b)) => visitor.visit_bool(b),
@@ -54,7 +54,7 @@ where
     where
         V: Visitor<'de>,
     {
-        match stry!(self.next()) {
+        match self.next()? {
             Node::Static(StaticNode::Bool(b)) => visitor.visit_bool(b),
             _c => Err(Deserializer::error(ErrorType::ExpectedBoolean)),
         }
@@ -94,7 +94,7 @@ where
     where
         V: Visitor<'de>,
     {
-        visitor.visit_i8(stry!(self.parse_i8()))
+        visitor.visit_i8(self.parse_i8()?)
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -103,7 +103,7 @@ where
     where
         V: Visitor<'de>,
     {
-        visitor.visit_i16(stry!(self.parse_i16()))
+        visitor.visit_i16(self.parse_i16()?)
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -112,7 +112,7 @@ where
     where
         V: Visitor<'de>,
     {
-        visitor.visit_i32(stry!(self.parse_i32()))
+        visitor.visit_i32(self.parse_i32()?)
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -120,7 +120,7 @@ where
     where
         V: Visitor<'de>,
     {
-        visitor.visit_i64(stry!(self.parse_i64()))
+        visitor.visit_i64( self.parse_i64()?)
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -128,7 +128,7 @@ where
     where
         V: Visitor<'de>,
     {
-        visitor.visit_i128(stry!(self.parse_i128()))
+        visitor.visit_i128(self.parse_i128()?)
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -137,7 +137,7 @@ where
     where
         V: Visitor<'de>,
     {
-        visitor.visit_u8(stry!(self.parse_u8()))
+        visitor.visit_u8(self.parse_u8()?)
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -146,7 +146,7 @@ where
     where
         V: Visitor<'de>,
     {
-        visitor.visit_u16(stry!(self.parse_u16()))
+        visitor.visit_u16(self.parse_u16()?)
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -155,7 +155,7 @@ where
     where
         V: Visitor<'de>,
     {
-        visitor.visit_u32(stry!(self.parse_u32()))
+        visitor.visit_u32(self.parse_u32()?)
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -163,7 +163,7 @@ where
     where
         V: Visitor<'de>,
     {
-        visitor.visit_u64(stry!(self.parse_u64()))
+        visitor.visit_u64(self.parse_u64()?)
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -171,7 +171,7 @@ where
     where
         V: Visitor<'de>,
     {
-        visitor.visit_u128(stry!(self.parse_u128()))
+        visitor.visit_u128(self.parse_u128()?)
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -180,7 +180,7 @@ where
     where
         V: Visitor<'de>,
     {
-        let v: f64 = stry!(self.parse_double());
+        let v: f64 = self.parse_double()?;
         visitor.visit_f32(v as f32)
     }
 
@@ -189,7 +189,7 @@ where
     where
         V: Visitor<'de>,
     {
-        visitor.visit_f64(stry!(self.parse_double()))
+        visitor.visit_f64(self.parse_double()?)
     }
 
     // An absent optional is represented as the JSON `null` and a present
@@ -206,7 +206,7 @@ where
     where
         V: Visitor<'de>,
     {
-        if stry!(self.peek()) == Node::Static(StaticNode::Null) {
+        if self.peek()? == Node::Static(StaticNode::Null) {
             self.skip();
             visitor.visit_unit()
         } else {
@@ -220,7 +220,7 @@ where
     where
         V: Visitor<'de>,
     {
-        if stry!(self.next()) != Node::Static(StaticNode::Null) {
+        if self.next()? != Node::Static(StaticNode::Null) {
             return Err(Deserializer::error(ErrorType::ExpectedNull));
         }
         visitor.visit_unit()
@@ -372,7 +372,7 @@ impl<'de> de::EnumAccess<'de> for VariantAccess<'_, 'de> {
     where
         V: de::DeserializeSeed<'de>,
     {
-        let val = stry!(seed.deserialize(&mut *self.de));
+        let val = seed.deserialize(&mut *self.de)?;
         Ok((val, self))
     }
 }
@@ -491,12 +491,12 @@ macro_rules! deserialize_integer_key {
         where
             V: de::Visitor<'de>,
         {
-            visitor.$visit(stry!(match stry!(self.de.next()) {
+            visitor.$visit(match self.de.next()? {
                 Node::String(s) => s
                     .parse::<$type>()
                     .map_err(|_| Deserializer::error(ErrorType::InvalidNumber)),
                 _ => Err(Deserializer::error(ErrorType::ExpectedString)),
-            }))
+            }?)
         }
     };
 }
@@ -509,12 +509,13 @@ impl<'de> de::Deserializer<'de> for MapKey<'de, '_> {
     where
         V: de::Visitor<'de>,
     {
-        match stry!(self.de.next()) {
+        match self.de.next()? {
             Node::String(s) => visitor.visit_borrowed_str(s),
             _ => Err(Deserializer::error(ErrorType::ExpectedString)),
         }
     }
-
+    
+    
     deserialize_integer_key!(deserialize_i8 => visit_i8; i8);
     deserialize_integer_key!(deserialize_i16 => visit_i16; i16);
     deserialize_integer_key!(deserialize_i32 => visit_i32; i32);

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -120,7 +120,7 @@ where
     where
         V: Visitor<'de>,
     {
-        visitor.visit_i64( self.parse_i64()?)
+        visitor.visit_i64(self.parse_i64()?)
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -514,8 +514,7 @@ impl<'de> de::Deserializer<'de> for MapKey<'de, '_> {
             _ => Err(Deserializer::error(ErrorType::ExpectedString)),
         }
     }
-    
-    
+
     deserialize_integer_key!(deserialize_i8 => visit_i8; i8);
     deserialize_integer_key!(deserialize_i16 => visit_i16; i16);
     deserialize_integer_key!(deserialize_i32 => visit_i32; i32);

--- a/src/serde/se/pp.rs
+++ b/src/serde/se/pp.rs
@@ -1,4 +1,4 @@
-use crate::{Error, ErrorType, macros::stry};
+use crate::{Error, ErrorType};
 use serde_ext::ser;
 use std::io::Write;
 use std::str;
@@ -87,7 +87,7 @@ where
             9 => self.get_writer().write_all(b"                  "),
             _ => {
                 for _ in 0..(self.dent * 2) {
-                    stry!(self.get_writer().write_all(b" "));
+                    self.get_writer().write_all(b" ")?;
                 }
                 Ok(())
             }

--- a/src/serde/value/borrowed/se.rs
+++ b/src/serde/value/borrowed/se.rs
@@ -363,7 +363,7 @@ impl<'se> serde::ser::SerializeMap for SerializeMap<'se> {
         T: ?Sized + Serialize,
     {
         self.next_key = Some(key.serialize(MapKeySerializer {
-            marker: PhantomData
+            marker: PhantomData,
         })?);
         Ok(())
     }

--- a/src/serde/value/borrowed/se.rs
+++ b/src/serde/value/borrowed/se.rs
@@ -2,7 +2,6 @@ use super::to_value;
 use crate::{
     Error, ErrorType, Result,
     cow::Cow,
-    macros::stry,
     value::borrowed::{Object, Value},
 };
 use crate::{ObjectHasher, StaticNode};
@@ -193,7 +192,7 @@ impl<'se> serde::Serializer for Serializer<'se> {
         T: ?Sized + Serialize,
     {
         let mut values = Object::with_capacity_and_hasher(1, ObjectHasher::default());
-        let x = stry!(to_value(value));
+        let x = to_value(value)?;
         unsafe { values.insert_nocheck(variant.into(), x) };
         Ok(Value::from(values))
     }
@@ -294,7 +293,7 @@ impl<'se> serde::ser::SerializeSeq for SerializeVec<'se> {
     where
         T: ?Sized + Serialize,
     {
-        self.vec.push(stry!(to_value(value)));
+        self.vec.push(to_value(value)?);
         Ok(())
     }
 
@@ -343,7 +342,7 @@ impl<'se> serde::ser::SerializeTupleVariant for SerializeTupleVariant<'se> {
     where
         T: ?Sized + Serialize,
     {
-        self.vec.push(stry!(to_value(value)));
+        self.vec.push(to_value(value)?);
         Ok(())
     }
 
@@ -363,9 +362,9 @@ impl<'se> serde::ser::SerializeMap for SerializeMap<'se> {
     where
         T: ?Sized + Serialize,
     {
-        self.next_key = Some(stry!(key.serialize(MapKeySerializer {
+        self.next_key = Some(key.serialize(MapKeySerializer {
             marker: PhantomData
-        })));
+        })?);
         Ok(())
     }
 
@@ -377,7 +376,7 @@ impl<'se> serde::ser::SerializeMap for SerializeMap<'se> {
         // Panic because this indicates a bug in the program rather than an
         // expected failure.
         let key = key.expect("serialize_value called before serialize_key");
-        self.map.insert(key, stry!(to_value(value)));
+        self.map.insert(key, to_value(value)?);
         Ok(())
     }
 
@@ -571,7 +570,7 @@ impl<'se> serde::ser::SerializeStruct for SerializeMap<'se> {
     where
         T: ?Sized + Serialize,
     {
-        stry!(serde::ser::SerializeMap::serialize_key(self, key));
+        serde::ser::SerializeMap::serialize_key(self, key)?;
         serde::ser::SerializeMap::serialize_value(self, value)
     }
 
@@ -588,7 +587,7 @@ impl<'se> serde::ser::SerializeStructVariant for SerializeStructVariant<'se> {
     where
         T: ?Sized + Serialize,
     {
-        self.map.insert(key.into(), stry!(to_value(value)));
+        self.map.insert(key.into(), to_value(value)?);
         Ok(())
     }
 

--- a/src/serde/value/owned/se.rs
+++ b/src/serde/value/owned/se.rs
@@ -1,7 +1,6 @@
 use super::to_value;
 use crate::{
     Error, ErrorType, ObjectHasher, Result, StaticNode,
-    macros::stry,
     value::owned::{Object, Value},
 };
 use serde_ext::ser::{
@@ -180,7 +179,7 @@ impl serde::Serializer for Serializer {
         T: ?Sized + Serialize,
     {
         let mut values = Object::with_capacity_and_hasher(1, ObjectHasher::default());
-        unsafe { values.insert_nocheck(variant.into(), stry!(to_value(value))) };
+        unsafe { values.insert_nocheck(variant.into(), to_value(value)?) };
         Ok(Value::from(values))
     }
 
@@ -280,7 +279,7 @@ impl serde::ser::SerializeSeq for SerializeVec {
     where
         T: ?Sized + Serialize,
     {
-        self.vec.push(stry!(to_value(value)));
+        self.vec.push(to_value(value)?);
         Ok(())
     }
 
@@ -329,7 +328,7 @@ impl serde::ser::SerializeTupleVariant for SerializeTupleVariant {
     where
         T: ?Sized + Serialize,
     {
-        self.vec.push(stry!(to_value(value)));
+        self.vec.push(to_value(value)?);
         Ok(())
     }
 
@@ -348,7 +347,7 @@ impl serde::ser::SerializeMap for SerializeMap {
     where
         T: ?Sized + Serialize,
     {
-        self.next_key = Some(stry!(key.serialize(MapKeySerializer {})));
+        self.next_key = Some(key.serialize(MapKeySerializer {})?);
         Ok(())
     }
 
@@ -360,7 +359,7 @@ impl serde::ser::SerializeMap for SerializeMap {
         // Panic because this indicates a bug in the program rather than an
         // expected failure.
         let key = key.expect("serialize_value called before serialize_key");
-        self.map.insert(key, stry!(to_value(value)));
+        self.map.insert(key, to_value(value)?);
         Ok(())
     }
 
@@ -551,7 +550,7 @@ impl serde::ser::SerializeStruct for SerializeMap {
     where
         T: ?Sized + Serialize,
     {
-        stry!(serde::ser::SerializeMap::serialize_key(self, key));
+        serde::ser::SerializeMap::serialize_key(self, key)?;
         serde::ser::SerializeMap::serialize_value(self, value)
     }
 
@@ -568,7 +567,7 @@ impl serde::ser::SerializeStructVariant for SerializeStructVariant {
     where
         T: ?Sized + Serialize,
     {
-        self.map.insert(key.into(), stry!(to_value(value)));
+        self.map.insert(key.into(), to_value(value)?);
         Ok(())
     }
 

--- a/src/value/borrowed/serialize.rs
+++ b/src/value/borrowed/serialize.rs
@@ -186,12 +186,12 @@ trait FastGenerator: BaseGenerator {
                         unreachable!("array is not empty but has no next");
                     };
 
-                   self.write(b"[")?;
-                   self.write_json(item)?;
+                    self.write(b"[")?;
+                    self.write_json(item)?;
 
                     for item in iter {
-                       self.write(b",")?;
-                       self.write_json(item)?;
+                        self.write(b",")?;
+                        self.write_json(item)?;
                     }
                     self.write(b"]")
                 }

--- a/src/value/borrowed/serialize.rs
+++ b/src/value/borrowed/serialize.rs
@@ -57,7 +57,7 @@ trait Generator: BaseGenerator {
             self.write(b"{}")
         } else {
             let mut iter = object.iter();
-            stry!(self.write(b"{"));
+            self.write(b"{")?;
 
             // We know this exists since it's not empty
             let Some((key, value)) = iter.next() else {
@@ -65,20 +65,20 @@ trait Generator: BaseGenerator {
                 unreachable!("object is not empty but has no next");
             };
             self.indent();
-            stry!(self.new_line());
-            stry!(self.write_simple_string(key));
-            stry!(self.write_min(b": ", b':'));
-            stry!(self.write_json(value));
+            self.new_line()?;
+            self.write_simple_string(key)?;
+            self.write_min(b": ", b':')?;
+            self.write_json(value)?;
 
             for (key, value) in iter {
-                stry!(self.write(b","));
-                stry!(self.new_line());
-                stry!(self.write_simple_string(key));
-                stry!(self.write_min(b": ", b':'));
-                stry!(self.write_json(value));
+                self.write(b",")?;
+                self.new_line()?;
+                self.write_simple_string(key)?;
+                self.write_min(b": ", b':')?;
+                self.write_json(value)?;
             }
             self.dedent();
-            stry!(self.new_line());
+            self.new_line()?;
             self.write(b"}")
         }
     }
@@ -109,19 +109,19 @@ trait Generator: BaseGenerator {
                         // We check against size
                         unreachable!("array is not empty but has no next");
                     };
-                    stry!(self.write(b"["));
+                    self.write(b"[")?;
                     self.indent();
 
-                    stry!(self.new_line());
-                    stry!(self.write_json(item));
+                    self.new_line()?;
+                    self.write_json(item)?;
 
                     for item in iter {
-                        stry!(self.write(b","));
-                        stry!(self.new_line());
-                        stry!(self.write_json(item));
+                        self.write(b",")?;
+                        self.new_line()?;
+                        self.write_json(item)?;
                     }
                     self.dedent();
-                    stry!(self.new_line());
+                    self.new_line()?;
                     self.write(b"]")
                 }
             }
@@ -139,22 +139,22 @@ trait FastGenerator: BaseGenerator {
             self.write(b"{}")
         } else {
             let mut iter = object.iter();
-            stry!(self.write(b"{\""));
+            self.write(b"{\"")?;
 
             // We know this exists since it's not empty
             let Some((key, value)) = iter.next() else {
                 // We check against size
                 unreachable!("object is not empty but has no next");
             };
-            stry!(self.write_simple_str_content(key));
-            stry!(self.write(b"\":"));
-            stry!(self.write_json(value));
+            self.write_simple_str_content(key)?;
+            self.write(b"\":")?;
+            self.write_json(value)?;
 
             for (key, value) in iter {
-                stry!(self.write(b",\""));
-                stry!(self.write_simple_str_content(key));
-                stry!(self.write(b"\":"));
-                stry!(self.write_json(value));
+                self.write(b",\"")?;
+                self.write_simple_str_content(key)?;
+                self.write(b"\":")?;
+                self.write_json(value)?;
             }
             self.write(b"}")
         }
@@ -186,12 +186,12 @@ trait FastGenerator: BaseGenerator {
                         unreachable!("array is not empty but has no next");
                     };
 
-                    stry!(self.write(b"["));
-                    stry!(self.write_json(item));
+                   self.write(b"[")?;
+                   self.write_json(item)?;
 
                     for item in iter {
-                        stry!(self.write(b","));
-                        stry!(self.write_json(item));
+                       self.write(b",")?;
+                       self.write_json(item)?;
                     }
                     self.write(b"]")
                 }

--- a/src/value/owned/serialize.rs
+++ b/src/value/owned/serialize.rs
@@ -71,11 +71,11 @@ trait Generator: BaseGenerator {
             self.write_json(value)?;
 
             for (key, value) in iter {
-               self.write(b",")?;
-               self.new_line()?;
-               self.write_simple_string(key)?;
-               self.write_min(b": ", b':')?;
-               self.write_json(value)?;
+                self.write(b",")?;
+                self.new_line()?;
+                self.write_simple_string(key)?;
+                self.write_min(b": ", b':')?;
+                self.write_json(value)?;
             }
             self.dedent();
             self.new_line()?;

--- a/src/value/owned/serialize.rs
+++ b/src/value/owned/serialize.rs
@@ -57,7 +57,7 @@ trait Generator: BaseGenerator {
             self.write(b"{}")
         } else {
             let mut iter = object.iter();
-            stry!(self.write(b"{"));
+            self.write(b"{")?;
 
             // We know this exists since it's not empty
             let Some((key, value)) = iter.next() else {
@@ -65,20 +65,20 @@ trait Generator: BaseGenerator {
                 unreachable!("object is not empty but has no next");
             };
             self.indent();
-            stry!(self.new_line());
-            stry!(self.write_simple_string(key));
-            stry!(self.write_min(b": ", b':'));
-            stry!(self.write_json(value));
+            self.new_line()?;
+            self.write_simple_string(key)?;
+            self.write_min(b": ", b':')?;
+            self.write_json(value)?;
 
             for (key, value) in iter {
-                stry!(self.write(b","));
-                stry!(self.new_line());
-                stry!(self.write_simple_string(key));
-                stry!(self.write_min(b": ", b':'));
-                stry!(self.write_json(value));
+               self.write(b",")?;
+               self.new_line()?;
+               self.write_simple_string(key)?;
+               self.write_min(b": ", b':')?;
+               self.write_json(value)?;
             }
             self.dedent();
-            stry!(self.new_line());
+            self.new_line()?;
             self.write(b"}")
         }
     }
@@ -110,20 +110,20 @@ trait Generator: BaseGenerator {
                         unreachable!("array is not empty but has no next");
                     };
 
-                    stry!(self.write(b"["));
+                    self.write(b"[")?;
 
                     self.indent();
-                    stry!(self.new_line());
-                    stry!(self.write_json(item));
+                    self.new_line()?;
+                    self.write_json(item)?;
 
                     for item in iter {
-                        stry!(self.write(b","));
-                        stry!(self.new_line());
-                        stry!(self.write_json(item));
+                        self.write(b",")?;
+                        self.new_line()?;
+                        self.write_json(item)?;
                     }
 
                     self.dedent();
-                    stry!(self.new_line());
+                    self.new_line()?;
                     self.write(b"]")
                 }
             }
@@ -141,22 +141,22 @@ trait FastGenerator: BaseGenerator {
             self.write(b"{}")
         } else {
             let mut iter = object.iter();
-            stry!(self.write(b"{\""));
+            self.write(b"{\"")?;
 
             // We know this exists since it's not empty
             let Some((key, value)) = iter.next() else {
                 // We check against size
                 unreachable!("object is not empty but has no next");
             };
-            stry!(self.write_simple_str_content(key));
-            stry!(self.write(b"\":"));
-            stry!(self.write_json(value));
+            self.write_simple_str_content(key)?;
+            self.write(b"\":")?;
+            self.write_json(value)?;
 
             for (key, value) in iter {
-                stry!(self.write(b",\""));
-                stry!(self.write_simple_str_content(key));
-                stry!(self.write(b"\":"));
-                stry!(self.write_json(value));
+                self.write(b",\"")?;
+                self.write_simple_str_content(key)?;
+                self.write(b"\":")?;
+                self.write_json(value)?;
             }
             self.write(b"}")
         }
@@ -188,12 +188,12 @@ trait FastGenerator: BaseGenerator {
                         unreachable!("array is not empty but has no next");
                     };
 
-                    stry!(self.write(b"["));
-                    stry!(self.write_json(item));
+                    self.write(b"[")?;
+                    self.write_json(item)?;
 
                     for item in iter {
-                        stry!(self.write(b","));
-                        stry!(self.write_json(item));
+                        self.write(b",")?;
+                        self.write_json(item)?;
                     }
                     self.write(b"]")
                 }

--- a/src/value/tape/trait_impls.rs
+++ b/src/value/tape/trait_impls.rs
@@ -715,17 +715,17 @@ trait Generator: BaseGenerator {
                 unreachable!("object is not empty but has no next");
             };
             self.indent();
+            self.new_line()?;
+            self.write_simple_string(key)?;
+            self.write_min(b": ", b':')?;
+            self.write_json(&value)?;
+
+            for (key, value) in iter {
+                self.write(b",")?;
                 self.new_line()?;
                 self.write_simple_string(key)?;
                 self.write_min(b": ", b':')?;
                 self.write_json(&value)?;
-
-            for (key, value) in iter {
-               self.write(b",")?;
-               self.new_line()?;
-               self.write_simple_string(key)?;
-               self.write_min(b": ", b':')?;
-               self.write_json(&value)?;
             }
             self.dedent();
             self.new_line()?;

--- a/src/value/tape/trait_impls.rs
+++ b/src/value/tape/trait_impls.rs
@@ -707,7 +707,7 @@ trait Generator: BaseGenerator {
             self.write(b"{}")
         } else {
             let mut iter = object.iter();
-            stry!(self.write(b"{"));
+            self.write(b"{")?;
 
             // We know this exists since it's not empty
             let Some((key, value)) = iter.next() else {
@@ -715,20 +715,20 @@ trait Generator: BaseGenerator {
                 unreachable!("object is not empty but has no next");
             };
             self.indent();
-            stry!(self.new_line());
-            stry!(self.write_simple_string(key));
-            stry!(self.write_min(b": ", b':'));
-            stry!(self.write_json(&value));
+                self.new_line()?;
+                self.write_simple_string(key)?;
+                self.write_min(b": ", b':')?;
+                self.write_json(&value)?;
 
             for (key, value) in iter {
-                stry!(self.write(b","));
-                stry!(self.new_line());
-                stry!(self.write_simple_string(key));
-                stry!(self.write_min(b": ", b':'));
-                stry!(self.write_json(&value));
+               self.write(b",")?;
+               self.new_line()?;
+               self.write_simple_string(key)?;
+               self.write_min(b": ", b':')?;
+               self.write_json(&value)?;
             }
             self.dedent();
-            stry!(self.new_line());
+            self.new_line()?;
             self.write(b"}")
         }
     }
@@ -761,19 +761,19 @@ trait Generator: BaseGenerator {
                         // We check against size
                         unreachable!("array is not empty but has no next");
                     };
-                    stry!(self.write(b"["));
+                    self.write(b"[")?;
                     self.indent();
 
-                    stry!(self.new_line());
-                    stry!(self.write_json(&item));
+                    self.new_line()?;
+                    self.write_json(&item)?;
 
                     for item in iter {
-                        stry!(self.write(b","));
-                        stry!(self.new_line());
-                        stry!(self.write_json(&item));
+                        self.write(b",")?;
+                        self.new_line()?;
+                        self.write_json(&item)?;
                     }
                     self.dedent();
-                    stry!(self.new_line());
+                    self.new_line()?;
                     self.write(b"]")
                 }
             }
@@ -791,22 +791,22 @@ trait FastGenerator: BaseGenerator {
             self.write(b"{}")
         } else {
             let mut iter = object.iter();
-            stry!(self.write(b"{\""));
+            self.write(b"{\"")?;
 
             // We know this exists since it's not empty
             let Some((key, value)) = iter.next() else {
                 // We check against size
                 unreachable!("object is not empty but has no next");
             };
-            stry!(self.write_simple_str_content(key));
-            stry!(self.write(b"\":"));
-            stry!(self.write_json(&value));
+            self.write_simple_str_content(key)?;
+            self.write(b"\":")?;
+            self.write_json(&value)?;
 
             for (key, value) in iter {
-                stry!(self.write(b",\""));
-                stry!(self.write_simple_str_content(key));
-                stry!(self.write(b"\":"));
-                stry!(self.write_json(&value));
+                self.write(b",\"")?;
+                self.write_simple_str_content(key)?;
+                self.write(b"\":")?;
+                self.write_json(&value)?;
             }
             self.write(b"}")
         }
@@ -839,12 +839,12 @@ trait FastGenerator: BaseGenerator {
                         unreachable!("array is not empty but has no next");
                     };
 
-                    stry!(self.write(b"["));
-                    stry!(self.write_json(&item));
+                    self.write(b"[")?;
+                    self.write_json(&item)?;
 
                     for item in iter {
-                        stry!(self.write(b","));
-                        stry!(self.write_json(&item));
+                        self.write(b",")?;
+                        self.write_json(&item)?;
                     }
                     self.write(b"]")
                 }


### PR DESCRIPTION
Closes #478 

1. [x] Remove `stry!` macro
2. [ ] Introduce newtype wrappers for improved readability and performance (if we don't use proper SIMD types)
3. [ ] Remove most fully qualified names